### PR TITLE
Add support for typealiased Dates

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -35,13 +35,13 @@
       "package": "Result",
       "reason": null,
       "repositoryURL": "https://github.com/antitypical/Result.git",
-      "version": "3.2.1"
+      "version": "3.2.3"
     },
     {
       "package": "SWXMLHash",
       "reason": null,
       "repositoryURL": "https://github.com/drmohundro/SWXMLHash.git",
-      "version": "3.0.4"
+      "version": "3.1.0"
     },
     {
       "package": "SourceKit",
@@ -53,13 +53,13 @@
       "package": "SourceKitten",
       "reason": null,
       "repositoryURL": "https://github.com/jpsim/SourceKitten.git",
-      "version": "0.17.2"
+      "version": "0.17.6"
     },
     {
       "package": "Sourcery",
       "reason": null,
       "repositoryURL": "https://github.com/krzysztofzablocki/Sourcery.git",
-      "version": "0.6.0"
+      "version": "0.6.1"
     },
     {
       "package": "Spectre",
@@ -71,13 +71,13 @@
       "package": "Stencil",
       "reason": null,
       "repositoryURL": "https://github.com/kylef/Stencil.git",
-      "version": "0.8.0"
+      "version": "0.9.0"
     },
     {
       "package": "StencilSwiftKit",
       "reason": null,
       "repositoryURL": "https://github.com/SwiftGen/StencilSwiftKit.git",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "package": "SwiftTryCatch",
@@ -89,13 +89,13 @@
       "package": "XcodeEdit",
       "reason": null,
       "repositoryURL": "https://github.com/tomlokhorst/XcodeEdit.git",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "package": "Yams",
       "reason": null,
       "repositoryURL": "https://github.com/jpsim/Yams.git",
-      "version": "0.3.1"
+      "version": "0.3.2"
     }
   ],
   "version": 1

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -110,4 +110,14 @@ extension SinglePropertyWithKeyPathAnnotation: JSONDeserializable {
     }
 }
 
+// MARK: - TypealiasedDateProperty AutoJSONDeserializable
+extension TypealiasedDateProperty: JSONDeserializable {
+    internal init?(JSONObject: [String: Any]) {
+        guard let momentInTime = (JSONObject["momentInTime"] as? String).flatMap(JSONDateFormatter.date(from:)) else { return nil }
+        self.momentInTime = momentInTime
+        let optionalMomentInTime = (JSONObject["optionalMomentInTime"] as? String).flatMap(JSONDateFormatter.date(from:))
+        self.optionalMomentInTime = optionalMomentInTime
+    }
+}
+
 // MARK: -

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -120,4 +120,12 @@ extension TypealiasedDateProperty: JSONDeserializable {
     }
 }
 
+// MARK: - TypealiasedDateArrayProperty AutoJSONDeserializable
+extension TypealiasedDateArrayProperty: JSONDeserializable {
+    internal init?(JSONObject: [String: Any]) {
+        guard let momentArray = (JSONObject["momentArray"] as? [String])?.flatMap(JSONDateFormatter.date(from:)) else { return nil }
+        self.momentArray = momentArray
+    }
+}
+
 // MARK: -

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
@@ -168,4 +168,16 @@ extension SinglePropertyWithKeyPathAnnotation: JSONSerializable {
     }
 }
 
+// MARK: - TypealiasedDateProperty AutoJSONSerializable
+extension TypealiasedDateProperty: JSONSerializable {
+    internal func toJSONObject() -> [String: Any] {
+        var jsonObject = [String: Any]()
+        let momentInTime = self.momentInTime.iso8601String()
+        jsonObject["momentInTime"] = momentInTime
+        let optionalMomentInTime = self.optionalMomentInTime?.iso8601String()
+        jsonObject["optionalMomentInTime"] = optionalMomentInTime
+        return jsonObject
+    }
+}
+
 // MARK: -

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
@@ -168,6 +168,16 @@ extension SinglePropertyWithKeyPathAnnotation: JSONSerializable {
     }
 }
 
+// MARK: - TypealiasedDateArrayProperty AutoJSONSerializable
+extension TypealiasedDateArrayProperty: JSONSerializable {
+    internal func toJSONObject() -> [String: Any] {
+        var jsonObject = [String: Any]()
+        let momentArray = self.momentArray.map { $0.iso8601String() }
+        jsonObject["momentArray"] = momentArray
+        return jsonObject
+    }
+}
+
 // MARK: - TypealiasedDateProperty AutoJSONSerializable
 extension TypealiasedDateProperty: JSONSerializable {
     internal func toJSONObject() -> [String: Any] {
@@ -176,16 +186,6 @@ extension TypealiasedDateProperty: JSONSerializable {
         jsonObject["momentInTime"] = momentInTime
         let optionalMomentInTime = self.optionalMomentInTime?.iso8601String()
         jsonObject["optionalMomentInTime"] = optionalMomentInTime
-        return jsonObject
-    }
-}
-
-// MARK: - TypealiasedDateArrayProperty AutoJSONSerializable
-extension TypealiasedDateArrayProperty: JSONSerializable {
-    internal func toJSONObject() -> [String: Any] {
-        var jsonObject = [String: Any]()
-        let momentArray = self.momentArray.map { $0.iso8601String() }
-        jsonObject["momentArray"] = momentArray
         return jsonObject
     }
 }

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
@@ -180,4 +180,14 @@ extension TypealiasedDateProperty: JSONSerializable {
     }
 }
 
+// MARK: - TypealiasedDateArrayProperty AutoJSONSerializable
+extension TypealiasedDateArrayProperty: JSONSerializable {
+    internal func toJSONObject() -> [String: Any] {
+        var jsonObject = [String: Any]()
+        let momentArray = self.momentArray.map { $0.iso8601String() }
+        jsonObject["momentArray"] = momentArray
+        return jsonObject
+    }
+}
+
 // MARK: -

--- a/Sources/AutoJSONSerialization/Models/ArrayProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/ArrayProperty.swift
@@ -8,6 +8,11 @@ struct DateArrayProperty: AutoJSONDeserializable, AutoJSONSerializable {
     let dateArray: [Date]
 }
 
+struct TypealiasedDateArrayProperty: AutoJSONSerializable {
+    typealias Moment = Date
+    let momentArray: [Moment]
+}
+
 struct BasicTypesArrayProperty: AutoJSONDeserializable, AutoJSONSerializable {
     let doubleArray: [Double]
     let integerArray: [Int]

--- a/Sources/AutoJSONSerialization/Models/ArrayProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/ArrayProperty.swift
@@ -8,7 +8,7 @@ struct DateArrayProperty: AutoJSONDeserializable, AutoJSONSerializable {
     let dateArray: [Date]
 }
 
-struct TypealiasedDateArrayProperty: AutoJSONSerializable {
+struct TypealiasedDateArrayProperty: AutoJSONDeserializable, AutoJSONSerializable {
     typealias Moment = Date
     let momentArray: [Moment]
 }

--- a/Sources/AutoJSONSerialization/Models/DateProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/DateProperty.swift
@@ -5,3 +5,10 @@ struct DateProperty: AutoJSONDeserializable, AutoJSONSerializable {
     // sourcery: JSONKey = "optional_date"
     let optionalDate: Date?
 }
+
+typealias MomentInTime = Date
+
+struct TypealiasedDateProperty: AutoJSONSerializable {
+    let momentInTime: MomentInTime
+    let optionalMomentInTime: MomentInTime?
+}

--- a/Sources/AutoJSONSerialization/Models/DateProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/DateProperty.swift
@@ -8,7 +8,7 @@ struct DateProperty: AutoJSONDeserializable, AutoJSONSerializable {
 
 typealias MomentInTime = Date
 
-struct TypealiasedDateProperty: AutoJSONSerializable {
+struct TypealiasedDateProperty: AutoJSONDeserializable, AutoJSONSerializable {
     let momentInTime: MomentInTime
     let optionalMomentInTime: MomentInTime?
 }

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -13,8 +13,8 @@ extension {{ type.name }}: JSONDeserializable {
         {% macro Optional arg %}guard {{ arg }} else { return nil }{% endmacro %}
         {% for variable in type.storedVariables %}
         {% ifnot variable.isArray %}
-        {% set castType %}{% if variable.type.implements.AutoJSONSerializable or variable.type.implements.JSONSerializable %}[String: Any]{% else %}{% if variable.unwrappedTypeName == "Date" %}String{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
-        {% set itemOperation %}{% if variable.type.implements.AutoJSONSerializable or variable.type.implements.JSONSerializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.unwrappedTypeName == "Date" %}.flatMap(JSONDateFormatter.date(from:)){% endif %}{% endif %}{% endset %}
+        {% set castType %}{% if variable.type.implements.AutoJSONSerializable or variable.type.implements.JSONSerializable %}[String: Any]{% else %}{% if variable.actualTypeName.unwrappedTypeName == "Date" %}String{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
+        {% set itemOperation %}{% if variable.type.implements.AutoJSONSerializable or variable.type.implements.JSONSerializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.actualTypeName.unwrappedTypeName == "Date" %}.flatMap(JSONDateFormatter.date(from:)){% endif %}{% endif %}{% endset %}
         {% set Assignment %}let {{ variable.name }} = (JSONObject["{{ variable.annotations.JSONKey|default:variable.name }}"] as? {{ castType }}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}

--- a/Templates/AutoJSONSerializable.stencil
+++ b/Templates/AutoJSONSerializable.stencil
@@ -51,7 +51,7 @@ extension {{ type.name }}: JSONSerializable {
         var jsonObject = [String: Any]()
         {% for variable in type.storedVariables %}
         {% ifnot variable.isArray %}
-        let {{ variable.name }} = self.{{ variable.name }}{% if variable.type.implements.AutoJSONSerializable or variable.type.implements.JSONSerializable %}{% if variable.isOptional %}?{%endif%}.toJSONObject(){% else %}{%if variable.unwrappedTypeName == "Date" %}{% if variable.isOptional %}?{%endif%}.iso8601String(){%endif%}{% endif %}
+        let {{ variable.name }} = self.{{ variable.name }}{% if variable.type.implements.AutoJSONSerializable or variable.type.implements.JSONSerializable %}{% if variable.isOptional %}?{%endif%}.toJSONObject(){% else %}{%if variable.actualTypeName.unwrappedTypeName == "Date" %}{% if variable.isOptional %}?{%endif%}.iso8601String(){%endif%}{% endif %}
         {% else %}
         let {{ variable.name }} = self.{{ variable.name }}.map { $0{% if variable.typeName.array.elementType.implements.AutoJSONSerializable or variable.typeName.array.elementType.implements.JSONSerializable %}.toJSONObject(){% else %}{%if variable.typeName.array.elementTypeName.unwrappedTypeName == "Date" %}{% if variable.typeName.array.elementTypeName.isOptional %}?{%endif%}.iso8601String(){%endif%}{% endif %} }
         {% endif %}

--- a/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
@@ -130,6 +130,20 @@ class AutoJSONDeserializableTests: XCTestCase {
         XCTAssertEqual(firstItem, expectedItem)
     }
 
+    func test_TypealiasedDateArrayPropertySerialization() {
+        let jsonObject: [String: Any] = [
+          "momentArray": ["1985-04-12T23:20:50Z"]
+        ]
+        let expectedItem = Date(timeIntervalSince1970: 482196050)
+
+        guard let object = TypealiasedDateArrayProperty(JSONObject: jsonObject),
+              let firstItem = object.momentArray.first else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(firstItem, expectedItem)
+    }
+
     func test_BasicTypesArrayPropertySerialization() {
         let jsonObject: [String: Any] = [
           "doubleArray": [1.2, 3.4],

--- a/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
@@ -81,6 +81,20 @@ class AutoJSONDeserializableTests: XCTestCase {
         XCTAssertEqual(object.optionalDate, Date(timeIntervalSince1970: 851042397))
     }
 
+    func test_TypealiasedDatePropertyDeserialization() {
+        let jsonObject: [String: Any] = [
+          "momentInTime": "1985-04-12T23:20:50Z",
+          "optionalMomentInTime": "1996-12-19T16:39:57-08:00"
+        ]
+
+        guard let object = TypealiasedDateProperty(JSONObject: jsonObject) else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(object.momentInTime, Date(timeIntervalSince1970: 482196050))
+        XCTAssertEqual(object.optionalMomentInTime, Date(timeIntervalSince1970: 851042397))
+    }
+
     func test_ArrayPropertySerialization() {
         let jsonObject: [String: Any] = [
           "array": [

--- a/Tests/AutoJSONSerializationTests/AutoJSONSerializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONSerializableTests.swift
@@ -112,6 +112,16 @@ class AutoJSONSerializableTests: XCTestCase {
         XCTAssertEqual(toString(object.toJSONObject()), toString(jsonObject))
     }
 
+    func test_TypealiasedDateArrayPropertySerialization() {
+        let arrayItem = Date(timeIntervalSince1970: 482196050)
+        let object = TypealiasedDateArrayProperty(momentArray: [arrayItem])
+        let jsonObject: [String: Any] = [
+          "momentArray": ["1985-04-12T23:20:50Z"]
+        ]
+
+        XCTAssertEqual(toString(object.toJSONObject()), toString(jsonObject))
+    }
+
     func test_BasicTypesArrayPropertySerialization() {
         let object = BasicTypesArrayProperty(doubleArray: [1.2, 3.4],
                                              integerArray: [1, 2, 3, 4],

--- a/Tests/AutoJSONSerializationTests/AutoJSONSerializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONSerializableTests.swift
@@ -70,6 +70,17 @@ class AutoJSONSerializableTests: XCTestCase {
         XCTAssertEqual(toString(object.toJSONObject()), toString(jsonObject))
     }
 
+    func test_TypealiasedDatePropertySerialization() {
+        let object = TypealiasedDateProperty(momentInTime: Date(timeIntervalSince1970: 482196050),
+                                             optionalMomentInTime: Date(timeIntervalSince1970: 851042397))
+        let jsonObject: [String: Any] = [
+          "momentInTime": "1985-04-12T23:20:50Z",
+          "optionalMomentInTime": "1996-12-20T00:39:57Z"
+        ]
+
+        XCTAssertEqual(toString(object.toJSONObject()), toString(jsonObject))
+    }
+
     func test_ArrayPropertySerialization() {
         let arrayItem = MultiTypesProperties(string: "value",
                                              integer: 42,

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 0.6.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 0.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 // swiftlint:disable file_length

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -18,6 +18,7 @@ extension AutoJSONDeserializableTests {
     ("test_TypealiasedDatePropertyDeserialization", test_TypealiasedDatePropertyDeserialization),
     ("test_ArrayPropertySerialization", test_ArrayPropertySerialization),
     ("test_DateArrayPropertySerialization", test_DateArrayPropertySerialization),
+    ("test_TypealiasedDateArrayPropertySerialization", test_TypealiasedDateArrayPropertySerialization),
     ("test_BasicTypesArrayPropertySerialization", test_BasicTypesArrayPropertySerialization),
   ]
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -15,6 +15,7 @@ extension AutoJSONDeserializableTests {
     ("test_OptionalPropertyDeserialization", test_OptionalPropertyDeserialization),
     ("test_JSONDeserializablePropertyDeserialization", test_JSONDeserializablePropertyDeserialization),
     ("test_DatePropertyDeserialization", test_DatePropertyDeserialization),
+    ("test_TypealiasedDatePropertyDeserialization", test_TypealiasedDatePropertyDeserialization),
     ("test_ArrayPropertySerialization", test_ArrayPropertySerialization),
     ("test_DateArrayPropertySerialization", test_DateArrayPropertySerialization),
     ("test_BasicTypesArrayPropertySerialization", test_BasicTypesArrayPropertySerialization),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -28,6 +28,7 @@ extension AutoJSONSerializableTests {
     ("test_OptionalPropertySerialization", test_OptionalPropertySerialization),
     ("test_JSONSerializablePropertySerialization", test_JSONSerializablePropertySerialization),
     ("test_DatePropertySerialization", test_DatePropertySerialization),
+    ("test_TypealiasedDatePropertySerialization", test_TypealiasedDatePropertySerialization),
     ("test_ArrayPropertySerialization", test_ArrayPropertySerialization),
     ("test_DateArrayPropertySerialization", test_DateArrayPropertySerialization),
     ("test_BasicTypesArrayPropertySerialization", test_BasicTypesArrayPropertySerialization),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -31,6 +31,7 @@ extension AutoJSONSerializableTests {
     ("test_TypealiasedDatePropertySerialization", test_TypealiasedDatePropertySerialization),
     ("test_ArrayPropertySerialization", test_ArrayPropertySerialization),
     ("test_DateArrayPropertySerialization", test_DateArrayPropertySerialization),
+    ("test_TypealiasedDateArrayPropertySerialization", test_TypealiasedDateArrayPropertySerialization),
     ("test_BasicTypesArrayPropertySerialization", test_BasicTypesArrayPropertySerialization),
   ]
 }


### PR DESCRIPTION
`Date` objects used through a typealias were not considered `Date` and not serialised/deserialized correctly.