### PR TITLE
Workaround the unsupported milliseconds part of ISO8601DateFormatter

### DIFF
--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONSerializable.generated.swift
@@ -9,7 +9,8 @@ import Foundation
 enum JSONDateFormatter {
     static func date(from string: String) -> Date? {
         if #available(iOS 10.0, macOS 10.12, *) {
-            return isoDateFormatter.date(from: string)
+            let dateString = string.replacingOccurrences(of: "\\.\\d+", with: "", options: .regularExpression)
+            return isoDateFormatter.date(from: dateString)
         } else {
             return dateFormatter.date(from: string)
         }

--- a/Templates/AutoJSONSerializable.stencil
+++ b/Templates/AutoJSONSerializable.stencil
@@ -6,7 +6,12 @@ import Foundation
 enum JSONDateFormatter {
     static func date(from string: String) -> Date? {
         if #available(iOS 10.0, macOS 10.12, *) {
-            return isoDateFormatter.date(from: string)
+            // [HACK] workaround for unsupported milliseconds part in ISO8601DateFormatter.
+            // "1985-04-12T23:20:50Z" is supported where "1985-04-12T23:20:50.678Z" is not.
+            // So this removes the ".678" part.
+            let dateString = string.replacingOccurrences(of: "\\.\\d+", with: "", options: .regularExpression)
+            // [/HACK]
+            return isoDateFormatter.date(from: dateString)
         } else {
             return dateFormatter.date(from: string)
         }

--- a/Tests/AutoJSONSerializationTests/JSONDateFormatterTests.swift
+++ b/Tests/AutoJSONSerializationTests/JSONDateFormatterTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import AutoJSONSerialization
+
+class JSONDateFormatterTests: XCTestCase {
+    func test_dateFromString() {
+        let expectedDate = Date(timeIntervalSince1970: 482196050)
+
+        let dateStrings = [
+          "1985-04-12T23:20:50Z",
+          "1985-04-12T22:20:50-01:00",
+          "1985-04-12T23:20:50.678Z",
+          "1985-04-12T22:20:50.467-01:00"
+        ]
+
+        dateStrings.forEach { dateString in
+            XCTAssertEqual(expectedDate,
+                           JSONDateFormatter.date(from: dateString),
+                           "Failed to correctly parse '\(dateString)'")
+        }
+    }
+
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -37,8 +37,14 @@ extension AutoJSONSerializableTests {
     ("test_BasicTypesArrayPropertySerialization", test_BasicTypesArrayPropertySerialization),
   ]
 }
+extension JSONDateFormatterTests {
+  static var allTests = [
+    ("test_dateFromString", test_dateFromString),
+  ]
+}
 
 XCTMain([
   testCase(AutoJSONDeserializableTests.allTests),
   testCase(AutoJSONSerializableTests.allTests),
+  testCase(JSONDateFormatterTests.allTests),
 ])


### PR DESCRIPTION
This seems to add a performance overhead between 17% and 25%