### PR TITLE
Generate code from annotations instead of protocol conformance

### DIFF
--- a/Sources/AutoJSONSerialization/AutoJSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/AutoJSONDeserializable.swift
@@ -1,5 +1,5 @@
-protocol AutoJSONDeserializable {}
+public protocol AutoJSONDeserializable {}
 
-protocol JSONDeserializable {
+public protocol JSONDeserializable {
     init?(JSONObject: Any)
 }

--- a/Sources/AutoJSONSerialization/AutoJSONSerializable.swift
+++ b/Sources/AutoJSONSerialization/AutoJSONSerializable.swift
@@ -1,5 +1,5 @@
-protocol AutoJSONSerializable {}
+public protocol AutoJSONSerializable {}
 
-protocol JSONSerializable {
+public protocol JSONSerializable {
     func toJSONObject() -> Any
 }

--- a/Sources/AutoJSONSerialization/Date+JSONSerialization.swift
+++ b/Sources/AutoJSONSerialization/Date+JSONSerialization.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 extension Date: JSONSerializable {
-    func toJSONObject() -> Any {
+    public func toJSONObject() -> Any {
         return JSONDateFormatter.string(from: self)
     }
 }
 
 extension Date: JSONDeserializable {
-    init?(JSONObject: Any) {
+    public init?(JSONObject: Any) {
         guard let dateString = JSONObject as? String,
               let date = JSONDateFormatter.date(from: dateString) else {
             return nil

--- a/Sources/AutoJSONSerialization/JSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/JSONDeserializable.swift
@@ -1,5 +1,3 @@
-public protocol AutoJSONDeserializable {}
-
 public protocol JSONDeserializable {
     init?(JSONObject: Any)
 }

--- a/Sources/AutoJSONSerialization/JSONSerializable.swift
+++ b/Sources/AutoJSONSerialization/JSONSerializable.swift
@@ -1,5 +1,3 @@
-public protocol AutoJSONSerializable {}
-
 public protocol JSONSerializable {
     func toJSONObject() -> Any
 }

--- a/Sources/AutoJSONSerialization/Models/ArrayProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/ArrayProperty.swift
@@ -1,24 +1,29 @@
 import Foundation
 
-struct ArrayProperty: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct ArrayProperty {
     let array: [MultiTypesProperties]
 }
 
-struct DateArrayProperty: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct DateArrayProperty {
     let dateArray: [Date]
 }
 
-struct TypealiasedDateArrayProperty: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct TypealiasedDateArrayProperty {
     typealias Moment = Date
     let momentArray: [Moment]
 }
 
-struct BasicTypesArrayProperty: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct BasicTypesArrayProperty {
     let doubleArray: [Double]
     let integerArray: [Int]
     let stringArray: [String]
 }
 
-struct EnumArrayProperty: AutoJSONSerializable, AutoJSONDeserializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct EnumArrayProperty {
     let enumsArray: [StringEnum]
 }

--- a/Sources/AutoJSONSerialization/Models/DateProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/DateProperty.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-struct DateProperty: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct DateProperty {
     let date: Date
     // sourcery: JSONKey = "optional_date"
     let optionalDate: Date?
@@ -8,7 +9,8 @@ struct DateProperty: AutoJSONDeserializable, AutoJSONSerializable {
 
 typealias MomentInTime = Date
 
-struct TypealiasedDateProperty: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct TypealiasedDateProperty {
     let momentInTime: MomentInTime
     let optionalMomentInTime: MomentInTime?
 }

--- a/Sources/AutoJSONSerialization/Models/EnumWithCustomSerdeProperties.swift
+++ b/Sources/AutoJSONSerialization/Models/EnumWithCustomSerdeProperties.swift
@@ -54,7 +54,8 @@ extension CustomSerdeEnum: Equatable {
     }
 }
 
-struct EnumWithCustomSerdeProperties: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct EnumWithCustomSerdeProperties {
     let intEnumUsingStringSerde: IntEnumUsingStringSerde
     let customSerdeEnum: CustomSerdeEnum
     let optionalCustomSerdeEnum: CustomSerdeEnum?

--- a/Sources/AutoJSONSerialization/Models/IntEnumProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/IntEnumProperty.swift
@@ -5,7 +5,8 @@ enum IntEnum: Int {
     case four = 4
 }
 
-struct IntEnumProperty: AutoJSONSerializable, AutoJSONDeserializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct IntEnumProperty {
     let enumValue: IntEnum
     let optionalEnumValue: IntEnum?
 }

--- a/Sources/AutoJSONSerialization/Models/JSONDeserializableProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/JSONDeserializableProperty.swift
@@ -1,4 +1,5 @@
-struct JSONDeserializableProperty: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct JSONDeserializableProperty {
     let entity: Entity
     let optionalEntity: Entity?
     let nilEntity: Entity?
@@ -7,7 +8,8 @@ struct JSONDeserializableProperty: AutoJSONDeserializable, AutoJSONSerializable 
     // sourcery: JSONKey = "optional_annotated_entity"
     let optionalAnnotatedEntity: Entity?
 
-    struct Entity: AutoJSONDeserializable, AutoJSONSerializable {
+    // sourcery: AutoJSONDeserializable, AutoJSONSerializable
+    struct Entity {
         let name: String
     }
 }

--- a/Sources/AutoJSONSerialization/Models/MultiTypesProperties.swift
+++ b/Sources/AutoJSONSerialization/Models/MultiTypesProperties.swift
@@ -1,4 +1,5 @@
-struct MultiTypesProperties: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct MultiTypesProperties {
     let string: String
     let integer: Int
     let optionalInteger: Int?

--- a/Sources/AutoJSONSerialization/Models/OptionalProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/OptionalProperty.swift
@@ -1,3 +1,4 @@
-struct OptionalProperty: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct OptionalProperty {
     let name: String?
 }

--- a/Sources/AutoJSONSerialization/Models/SinglePropertyNoAnnotation.swift
+++ b/Sources/AutoJSONSerialization/Models/SinglePropertyNoAnnotation.swift
@@ -1,3 +1,4 @@
-struct SinglePropertyNoAnnotation: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct SinglePropertyNoAnnotation {
     let name: String
 }

--- a/Sources/AutoJSONSerialization/Models/SinglePropertyWithKeyPathAnnotation.swift
+++ b/Sources/AutoJSONSerialization/Models/SinglePropertyWithKeyPathAnnotation.swift
@@ -1,4 +1,5 @@
-struct SinglePropertyWithKeyPathAnnotation: AutoJSONDeserializable, AutoJSONSerializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct SinglePropertyWithKeyPathAnnotation {
     // sourcery: JSONKey = "label"
     let name: String
 }

--- a/Sources/AutoJSONSerialization/Models/StringEnumProperty.swift
+++ b/Sources/AutoJSONSerialization/Models/StringEnumProperty.swift
@@ -4,7 +4,8 @@ enum StringEnum: String {
     case assignedValue = "assigned_value"
 }
 
-struct StringEnumProperty: AutoJSONSerializable, AutoJSONDeserializable {
+// sourcery: AutoJSONDeserializable, AutoJSONSerializable
+struct StringEnumProperty {
     let enumValue: StringEnum
     let optionalEnumValue: StringEnum?
 }

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -3,18 +3,18 @@
 import Foundation
 
 // MARK: - AutoJSONDeserializable for classes, protocols, structs
-{% for type in types.implementing.AutoJSONDeserializable %}
+{% for type in types.all|annotated:"AutoJSONDeserializable" %}
 
 // MARK: - {{ type.name }} AutoJSONDeserializable
 extension {{ type.name }}: JSONDeserializable {
-{% if type.supertype.implements.AutoJSONDeserializable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoJSONDeserializable {% endif %}
+{% if type.supertype|annotated:"AutoJSONDeserializable" %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoJSONDeserializable {% endif %}
     {{ type.accessLevel }} init?(JSONObject: Any) {
         guard let JSONObject = JSONObject as? [String: Any] else { return nil }
         {% macro Optional arg %}guard {{ arg }} else { return nil }{% endmacro %}
         {% for variable in type.storedVariables %}
         {% ifnot variable.isArray %}
-        {% set castType %}{% if variable.type.implements.AutoJSONDeserializable or variable.type.implements.JSONDeserializable %}{% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ variable.type.rawTypeName.name }}{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
-        {% set itemOperation %}{% if variable.type.implements.AutoJSONDeserializable or variable.type.implements.JSONDeserializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}.flatMap({ {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
+        {% set castType %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.implements.JSONDeserializable %}{% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ variable.type.rawTypeName.name }}{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
+        {% set itemOperation %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.implements.JSONDeserializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}.flatMap({ {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
         {% set Assignment %}let {{ variable.name }} = (JSONObject["{{ variable.annotations.JSONKey|default:variable.name }}"] {% if castType %}as? {% endif %}{{ castType }}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}
@@ -22,8 +22,8 @@ extension {{ type.name }}: JSONDeserializable {
         {% call Optional Assignment %}
         {% endif %}
         {% else %}
-        {% set castType %}{% if variable.typeName.array.elementType.implements.AutoJSONDeserializable or variable.typeName.array.elementType.implements.JSONDeserializable %}[Any]{% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}[{{ variable.typeName.array.elementType.rawTypeName.name }}]{% else %}{{ variable.typeName }}{% endif %}{% endif %}{% endset %}
-        {% set itemOperation %}{% if variable.typeName.array.elementType.implements.AutoJSONDeserializable or variable.typeName.array.elementType.implements.JSONDeserializable %}?.flatMap({{ variable.typeName.array.elementTypeName.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}?.flatMap({ {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
+        {% set castType %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.implements.JSONDeserializable %}[Any]{% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}[{{ variable.typeName.array.elementType.rawTypeName.name }}]{% else %}{{ variable.typeName }}{% endif %}{% endif %}{% endset %}
+        {% set itemOperation %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.implements.JSONDeserializable %}?.flatMap({{ variable.typeName.array.elementTypeName.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}?.flatMap({ {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
         {% set Assignment %}let {{ variable.name }} = (JSONObject["{{ variable.annotations.JSONKey|default:variable.name }}"] as? {{ castType }}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}

--- a/Templates/AutoJSONSerializable.stencil
+++ b/Templates/AutoJSONSerializable.stencil
@@ -3,20 +3,20 @@
 import Foundation
 
 // MARK: - AutoJSONSerializable for classes, protocols, structs
-{% for type in types.implementing.AutoJSONSerializable %}
+{% for type in types.all|annotated:"AutoJSONSerializable" %}
 
 // MARK: - {{ type.name }} AutoJSONSerializable
 extension {{ type.name }}: JSONSerializable {
-{% if type.supertype.implements.AutoJSONSerializable %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoJSONSerializable {% endif %}
+{% if type.supertype|annotated:"AutoJSONSerializable" %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoJSONSerializable {% endif %}
     {{ type.accessLevel }} func toJSONObject() -> Any {
         var jsonObject = [String: Any]()
         {% for variable in type.storedVariables %}
         {% ifnot variable.isArray %}
         {% set optionalTrait %}{% if variable.isOptional %}?{%endif%}{% endset %}
-        let {{ variable.name }} = self.{{ variable.name }}{% if variable.type.implements.AutoJSONSerializable or variable.type.implements.JSONSerializable %}{{ optionalTrait }}.toJSONObject(){% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ optionalTrait }}.rawValue{%endif%}{% endif %}
+        let {{ variable.name }} = self.{{ variable.name }}{% if variable.type|annotated:"AutoJSONSerializable" or variable.type.implements.JSONSerializable %}{{ optionalTrait }}.toJSONObject(){% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ optionalTrait }}.rawValue{%endif%}{% endif %}
         {% else %}
         {% set optionalTrait %}{% if variable.typeName.array.elementTypeName.isOptional %}?{%endif%}{% endset %}
-        let {{ variable.name }} = self.{{ variable.name }}.map { $0{% if variable.typeName.array.elementType.implements.AutoJSONSerializable or variable.typeName.array.elementType.implements.JSONSerializable %}.toJSONObject(){% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}{{ optionalTrait }}.rawValue{% endif %}{%endif%} }
+        let {{ variable.name }} = self.{{ variable.name }}.map { $0{% if variable.typeName.array.elementType|annotated:"AutoJSONSerializable" or variable.typeName.array.elementType.implements.JSONSerializable %}.toJSONObject(){% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}{{ optionalTrait }}.rawValue{% endif %}{%endif%} }
         {% endif %}
         jsonObject["{{ variable.annotations.JSONKey|default:variable.name }}"] = {{ variable.name }}
         {% endfor %}


### PR DESCRIPTION
This implements #3 

This removes the need to have _placeholder_ protocols to generate the code.
You just need to add Sourcery annotations `AutoJSONSerializable` and `AutoJSONDeserializable` to generate the implementation of `JSONSerializable` and `JSONDeserializable`.