### PR TITLE
Embed protocols in pod

### DIFF
--- a/.sourcery.yml
+++ b/.sourcery.yml
@@ -5,3 +5,5 @@ templates:
 output:
   Sources/AutoJSONSerialization/Extensions/
 prune: true
+args:
+  removePodImport: true

--- a/README.md
+++ b/README.md
@@ -50,12 +50,13 @@ protocol JSONSerializable {
 ```
 
 With this tool, you do not need to implement these protocols, the Sourcery templates will do the boiler plate code for you.  
-To do this, all you need to do is conform to one (or both) of these protocols:
+To do this, all you need to do is add sourcery annotations to you `struct`s:
 
 ``` swift
-protocol AutoJSONDeserializable {}
-
-protocol AutoJSONSerializable {}
+// sourcery: AutoJSONSerializable, AutoJSONDeserializable
+struct Contact {
+    // ...
+}
 ```
 
 And then run Sourcery using the templates found in the `Templates/` folder of this repository.
@@ -73,7 +74,7 @@ struct Contact {
 }
 ```
 
-Making it conform to AutoJSONDeserializable would result make it support this JSON:
+Adding the `AutoJSONDeserializable` annotation would make it initializable from this JSON data:
 
 ``` json
 {
@@ -94,12 +95,14 @@ Making it conform to AutoJSONDeserializable would result make it support this JS
   * Arrays of primitive JSON types, `enum`s and JSON*able types.
   * JSONKey annotation.
   
+⚠️ This system does not support `class` types because an extension can only declare `convenience` initializers ⚠️
+
 ⚠️ `Date`s are not supported out of the box anymore ⚠️ 
 
 Because _almost_ every project use a different date format to communicate with the server the embedded implementation has been removed. You can support `Date`s by providing your implementation.  
 However, you can still find an implementation for `Date`s Serialization/Deserialization using `ISO8601DateFormatter` with milliseconds support in the testing code [here](https://github.com/Liquidsoul/Sourcery-AutoJSONSerializable/blob/master/Sources/AutoJSONSerialization/Date%2BJSONSerialization.swift).
 
-## Annotations ##
+## Attributes annotations ##
 
 When mapping your JSON to your model structure, you may sometimes want to use a different attribute name as the one in the JSON file.  
 Let's say you have this JSON:
@@ -163,34 +166,28 @@ templates:
   […]
 ```
 
-Add those protocols anywhere in your source code:
+And, to use it on a structure, just add one of the "Auto" annotation:
 
 ``` swift
-protocol AutoJSONSerializable {}
-protocol AutoJSONDeserializable {}
-
-public protocol JSONSerializable {
-    func toJSONObject() -> Any
-}
-
-protocol JSONDeserializable {
-    init?(JSONObject: Any)
-}
-```
-
-And, finally, to use it on a structure, just add one of the "Auto" protocols:
-
-``` swift
-struct Contact: AutoJSONSerializable {
+// sourcery: AutoJSONSerializable
+struct Contact {
     [...]
 }
 ```
 
+This will generate two files to add to your project:
+- `AutoJSONSerializable.generated.swift`
+- `AutoJSONDeserializable.generated.swift`
+
+You can specify the output folder for these files using the `output` option in your `.sourcery.yml`. See [Soucery documentation](https://github.com/krzysztofzablocki/Sourcery#configuration-file) for more details.
+
+If you want to provide custom `JSONSerializable` or `JSONDeserializable` implementations, just import the module `Sourcery_AutoJSONSerializable` to gain access to the protocols.
+
 ## Manual Install ##
 
 To install just copy the following source files in your project:
-  * `Sources/AutoJSONSerialization/AutoJSONSerializable.swift`
-  * `Sources/AutoJSONSerialization/AutoJSONDeserializable.swift`
+  * `Sources/AutoJSONSerialization/JSONSerializable.swift`
+  * `Sources/AutoJSONSerialization/JSONDeserializable.swift`
 
 And then copy the Templates files and configure Sourcery.
 

--- a/Sourcery-AutoJSONSerializable.podspec
+++ b/Sourcery-AutoJSONSerializable.podspec
@@ -15,4 +15,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
 
   s.preserve_paths = 'Templates'
+  s.source_files = 'Sources/AutoJSONSerialization/JSONSerializable.swift', 'Sources/AutoJSONSerialization/JSONDeserializable.swift'
 end

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -16,8 +16,8 @@ extension {{ type.name }}: JSONDeserializable {
         {% macro Optional arg %}guard {{ arg }} else { return nil }{% endmacro %}
         {% for variable in type.storedVariables %}
         {% ifnot variable.isArray %}
-        {% set castType %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.implements.JSONDeserializable %}{% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ variable.type.rawTypeName.name }}{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
-        {% set itemOperation %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.implements.JSONDeserializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}.flatMap({ {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
+        {% set castType %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}{% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ variable.type.rawTypeName.name }}{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
+        {% set itemOperation %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}.flatMap({ {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
         {% set Assignment %}let {{ variable.name }} = (JSONObject["{{ variable.annotations.JSONKey|default:variable.name }}"] {% if castType %}as? {% endif %}{{ castType }}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}
@@ -25,8 +25,8 @@ extension {{ type.name }}: JSONDeserializable {
         {% call Optional Assignment %}
         {% endif %}
         {% else %}
-        {% set castType %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.implements.JSONDeserializable %}[Any]{% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}[{{ variable.typeName.array.elementType.rawTypeName.name }}]{% else %}{{ variable.typeName }}{% endif %}{% endif %}{% endset %}
-        {% set itemOperation %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.implements.JSONDeserializable %}?.flatMap({{ variable.typeName.array.elementTypeName.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}?.flatMap({ {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
+        {% set castType %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}[Any]{% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}[{{ variable.typeName.array.elementType.rawTypeName.name }}]{% else %}{{ variable.typeName }}{% endif %}{% endif %}{% endset %}
+        {% set itemOperation %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}?.flatMap({{ variable.typeName.array.elementTypeName.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}?.flatMap({ {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
         {% set Assignment %}let {{ variable.name }} = (JSONObject["{{ variable.annotations.JSONKey|default:variable.name }}"] as? {{ castType }}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -1,6 +1,9 @@
 // swiftlint:disable cyclomatic_complexity file_length function_body_length line_length
 
 import Foundation
+{% ifnot argument.removePodImport %}
+import Sourcery_AutoJSONSerializable
+{% endif %}
 
 // MARK: - AutoJSONDeserializable for classes, protocols, structs
 {% for type in types.all|annotated:"AutoJSONDeserializable" %}

--- a/Templates/AutoJSONSerializable.stencil
+++ b/Templates/AutoJSONSerializable.stencil
@@ -16,10 +16,10 @@ extension {{ type.name }}: JSONSerializable {
         {% for variable in type.storedVariables %}
         {% ifnot variable.isArray %}
         {% set optionalTrait %}{% if variable.isOptional %}?{%endif%}{% endset %}
-        let {{ variable.name }} = self.{{ variable.name }}{% if variable.type|annotated:"AutoJSONSerializable" or variable.type.implements.JSONSerializable %}{{ optionalTrait }}.toJSONObject(){% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ optionalTrait }}.rawValue{%endif%}{% endif %}
+        let {{ variable.name }} = self.{{ variable.name }}{% if variable.type|annotated:"AutoJSONSerializable" or variable.type.based.JSONSerializable %}{{ optionalTrait }}.toJSONObject(){% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ optionalTrait }}.rawValue{%endif%}{% endif %}
         {% else %}
         {% set optionalTrait %}{% if variable.typeName.array.elementTypeName.isOptional %}?{%endif%}{% endset %}
-        let {{ variable.name }} = self.{{ variable.name }}.map { $0{% if variable.typeName.array.elementType|annotated:"AutoJSONSerializable" or variable.typeName.array.elementType.implements.JSONSerializable %}.toJSONObject(){% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}{{ optionalTrait }}.rawValue{% endif %}{%endif%} }
+        let {{ variable.name }} = self.{{ variable.name }}.map { $0{% if variable.typeName.array.elementType|annotated:"AutoJSONSerializable" or variable.typeName.array.elementType.based.JSONSerializable %}.toJSONObject(){% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}{{ optionalTrait }}.rawValue{% endif %}{%endif%} }
         {% endif %}
         jsonObject["{{ variable.annotations.JSONKey|default:variable.name }}"] = {{ variable.name }}
         {% endfor %}

--- a/Templates/AutoJSONSerializable.stencil
+++ b/Templates/AutoJSONSerializable.stencil
@@ -1,6 +1,9 @@
 // swiftlint:disable cyclomatic_complexity file_length function_body_length line_length
 
 import Foundation
+{% ifnot argument.removePodImport %}
+import Sourcery_AutoJSONSerializable
+{% endif %}
 
 // MARK: - AutoJSONSerializable for classes, protocols, structs
 {% for type in types.all|annotated:"AutoJSONSerializable" %}


### PR DESCRIPTION
This removes the necessity of adding code manually in the user's codebase.
The only remaining manual step is to configure Sourcery to run on the project.