### PR TITLE
Add parsing error handling with throwable init

### DIFF
--- a/Sources/AutoJSONSerialization/Date+JSONSerialization.swift
+++ b/Sources/AutoJSONSerialization/Date+JSONSerialization.swift
@@ -7,10 +7,10 @@ extension Date: JSONSerializable {
 }
 
 extension Date: JSONDeserializable {
-    public init?(JSONObject: Any) {
+    public init(JSONObject: Any) throws {
         guard let dateString = JSONObject as? String,
               let date = JSONDateFormatter.date(from: dateString) else {
-            return nil
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
         self = date
     }

--- a/Sources/AutoJSONSerialization/Date+JSONSerialization.swift
+++ b/Sources/AutoJSONSerialization/Date+JSONSerialization.swift
@@ -10,7 +10,7 @@ extension Date: JSONDeserializable {
     public init(JSONObject: Any) throws {
         guard let dateString = JSONObject as? String,
               let date = JSONDateFormatter.date(from: dateString) else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError(String.self)
         }
         self = date
     }

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -13,13 +13,18 @@ extension ArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
+        let arrayRawValue = JSONDictionary["array"]
+        if arrayRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("array")
+        }
         do {
-        guard let array = try (JSONDictionary["array"] as? [Any])?.flatMap(MultiTypesProperties.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "array", value: JSONDictionary["array"])
+        guard let array = try (arrayRawValue as? [Any])?.flatMap(MultiTypesProperties.init(JSONObject:)) else {
+            // type: [MultiTypesProperties]
+            throw AutoJSONDeserializableError.typeMismatchError([MultiTypesProperties].self)
         }
         self.array = array
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "array", error: error)
+            throw error.nestedUnderKey("array")
         }
     }
 }
@@ -30,18 +35,45 @@ extension BasicTypesArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        guard let doubleArray = (JSONDictionary["doubleArray"] as? [Double]) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "doubleArray", value: JSONDictionary["doubleArray"])
+        let doubleArrayRawValue = JSONDictionary["doubleArray"]
+        if doubleArrayRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("doubleArray")
+        }
+        do {
+        guard let doubleArray = (doubleArrayRawValue as? [Double]) else {
+            // type: [Double]
+            throw AutoJSONDeserializableError.typeMismatchError([Double].self)
         }
         self.doubleArray = doubleArray
-        guard let integerArray = (JSONDictionary["integerArray"] as? [Int]) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "integerArray", value: JSONDictionary["integerArray"])
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("doubleArray")
+        }
+        let integerArrayRawValue = JSONDictionary["integerArray"]
+        if integerArrayRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("integerArray")
+        }
+        do {
+        guard let integerArray = (integerArrayRawValue as? [Int]) else {
+            // type: [Int]
+            throw AutoJSONDeserializableError.typeMismatchError([Int].self)
         }
         self.integerArray = integerArray
-        guard let stringArray = (JSONDictionary["stringArray"] as? [String]) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "stringArray", value: JSONDictionary["stringArray"])
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("integerArray")
+        }
+        let stringArrayRawValue = JSONDictionary["stringArray"]
+        if stringArrayRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("stringArray")
+        }
+        do {
+        guard let stringArray = (stringArrayRawValue as? [String]) else {
+            // type: [String]
+            throw AutoJSONDeserializableError.typeMismatchError([String].self)
         }
         self.stringArray = stringArray
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("stringArray")
+        }
     }
 }
 
@@ -51,13 +83,18 @@ extension DateArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
+        let dateArrayRawValue = JSONDictionary["dateArray"]
+        if dateArrayRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("dateArray")
+        }
         do {
-        guard let dateArray = try (JSONDictionary["dateArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "dateArray", value: JSONDictionary["dateArray"])
+        guard let dateArray = try (dateArrayRawValue as? [Any])?.flatMap(Date.init(JSONObject:)) else {
+            // type: [Date]
+            throw AutoJSONDeserializableError.typeMismatchError([Date].self)
         }
         self.dateArray = dateArray
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "dateArray", error: error)
+            throw error.nestedUnderKey("dateArray")
         }
     }
 }
@@ -68,19 +105,25 @@ extension DateProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
+        let dateRawValue = JSONDictionary["date"]
+        if dateRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("date")
+        }
         do {
-        guard let date = try (JSONDictionary["date"]).flatMap(Date.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "date", value: JSONDictionary["date"])
+        guard let date = try (dateRawValue).flatMap(Date.init(JSONObject:)) else {
+            // type: Date
+            throw AutoJSONDeserializableError.typeMismatchError(Date.self)
         }
         self.date = date
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "date", error: error)
+            throw error.nestedUnderKey("date")
         }
+        let optionalDateRawValue = JSONDictionary["optional_date"]
         do {
-        let optionalDate = try (JSONDictionary["optional_date"]).flatMap(Date.init(JSONObject:))
+        let optionalDate = try (optionalDateRawValue).flatMap(Date.init(JSONObject:))
         self.optionalDate = optionalDate
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "optional_date", error: error)
+            throw error.nestedUnderKey("optional_date")
         }
     }
 }
@@ -91,10 +134,19 @@ extension EnumArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        guard let enumsArray = (JSONDictionary["enumsArray"] as? [String])?.flatMap({ StringEnum(rawValue: $0) }) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumsArray", value: JSONDictionary["enumsArray"])
+        let enumsArrayRawValue = JSONDictionary["enumsArray"]
+        if enumsArrayRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("enumsArray")
+        }
+        do {
+        guard let enumsArray = (enumsArrayRawValue as? [String])?.flatMap({ StringEnum(rawValue: $0) }) else {
+            // type: [StringEnum]
+            throw AutoJSONDeserializableError.typeMismatchError([StringEnum].self)
         }
         self.enumsArray = enumsArray
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("enumsArray")
+        }
     }
 }
 
@@ -104,27 +156,38 @@ extension EnumWithCustomSerdeProperties: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
+        let intEnumUsingStringSerdeRawValue = JSONDictionary["intEnumUsingStringSerde"]
+        if intEnumUsingStringSerdeRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("intEnumUsingStringSerde")
+        }
         do {
-        guard let intEnumUsingStringSerde = try (JSONDictionary["intEnumUsingStringSerde"]).flatMap(IntEnumUsingStringSerde.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "intEnumUsingStringSerde", value: JSONDictionary["intEnumUsingStringSerde"])
+        guard let intEnumUsingStringSerde = try (intEnumUsingStringSerdeRawValue).flatMap(IntEnumUsingStringSerde.init(JSONObject:)) else {
+            // type: IntEnumUsingStringSerde
+            throw AutoJSONDeserializableError.typeMismatchError(IntEnumUsingStringSerde.self)
         }
         self.intEnumUsingStringSerde = intEnumUsingStringSerde
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "intEnumUsingStringSerde", error: error)
+            throw error.nestedUnderKey("intEnumUsingStringSerde")
+        }
+        let customSerdeEnumRawValue = JSONDictionary["customSerdeEnum"]
+        if customSerdeEnumRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("customSerdeEnum")
         }
         do {
-        guard let customSerdeEnum = try (JSONDictionary["customSerdeEnum"]).flatMap(CustomSerdeEnum.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "customSerdeEnum", value: JSONDictionary["customSerdeEnum"])
+        guard let customSerdeEnum = try (customSerdeEnumRawValue).flatMap(CustomSerdeEnum.init(JSONObject:)) else {
+            // type: CustomSerdeEnum
+            throw AutoJSONDeserializableError.typeMismatchError(CustomSerdeEnum.self)
         }
         self.customSerdeEnum = customSerdeEnum
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "customSerdeEnum", error: error)
+            throw error.nestedUnderKey("customSerdeEnum")
         }
+        let optionalCustomSerdeEnumRawValue = JSONDictionary["optionalCustomSerdeEnum"]
         do {
-        let optionalCustomSerdeEnum = try (JSONDictionary["optionalCustomSerdeEnum"]).flatMap(CustomSerdeEnum.init(JSONObject:))
+        let optionalCustomSerdeEnum = try (optionalCustomSerdeEnumRawValue).flatMap(CustomSerdeEnum.init(JSONObject:))
         self.optionalCustomSerdeEnum = optionalCustomSerdeEnum
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "optionalCustomSerdeEnum", error: error)
+            throw error.nestedUnderKey("optionalCustomSerdeEnum")
         }
     }
 }
@@ -135,11 +198,21 @@ extension IntEnumProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        guard let enumValue = (JSONDictionary["enumValue"] as? Int).flatMap({ IntEnum(rawValue: $0) }) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumValue", value: JSONDictionary["enumValue"])
+        let enumValueRawValue = JSONDictionary["enumValue"]
+        if enumValueRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("enumValue")
+        }
+        do {
+        guard let enumValue = (enumValueRawValue as? Int).flatMap({ IntEnum(rawValue: $0) }) else {
+            // type: IntEnum
+            throw AutoJSONDeserializableError.typeMismatchError(IntEnum.self)
         }
         self.enumValue = enumValue
-        let optionalEnumValue = (JSONDictionary["optionalEnumValue"] as? Int).flatMap({ IntEnum(rawValue: $0) })
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("enumValue")
+        }
+        let optionalEnumValueRawValue = JSONDictionary["optionalEnumValue"]
+        let optionalEnumValue = (optionalEnumValueRawValue as? Int).flatMap({ IntEnum(rawValue: $0) })
         self.optionalEnumValue = optionalEnumValue
     }
 }
@@ -150,39 +223,52 @@ extension JSONDeserializableProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
+        let entityRawValue = JSONDictionary["entity"]
+        if entityRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("entity")
+        }
         do {
-        guard let entity = try (JSONDictionary["entity"]).flatMap(Entity.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "entity", value: JSONDictionary["entity"])
+        guard let entity = try (entityRawValue).flatMap(Entity.init(JSONObject:)) else {
+            // type: Entity
+            throw AutoJSONDeserializableError.typeMismatchError(Entity.self)
         }
         self.entity = entity
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "entity", error: error)
+            throw error.nestedUnderKey("entity")
         }
+        let optionalEntityRawValue = JSONDictionary["optionalEntity"]
         do {
-        let optionalEntity = try (JSONDictionary["optionalEntity"]).flatMap(Entity.init(JSONObject:))
+        let optionalEntity = try (optionalEntityRawValue).flatMap(Entity.init(JSONObject:))
         self.optionalEntity = optionalEntity
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "optionalEntity", error: error)
+            throw error.nestedUnderKey("optionalEntity")
         }
+        let nilEntityRawValue = JSONDictionary["nilEntity"]
         do {
-        let nilEntity = try (JSONDictionary["nilEntity"]).flatMap(Entity.init(JSONObject:))
+        let nilEntity = try (nilEntityRawValue).flatMap(Entity.init(JSONObject:))
         self.nilEntity = nilEntity
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "nilEntity", error: error)
+            throw error.nestedUnderKey("nilEntity")
+        }
+        let annotatedEntityRawValue = JSONDictionary["annotated_entity"]
+        if annotatedEntityRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("annotated_entity")
         }
         do {
-        guard let annotatedEntity = try (JSONDictionary["annotated_entity"]).flatMap(Entity.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "annotated_entity", value: JSONDictionary["annotated_entity"])
+        guard let annotatedEntity = try (annotatedEntityRawValue).flatMap(Entity.init(JSONObject:)) else {
+            // type: Entity
+            throw AutoJSONDeserializableError.typeMismatchError(Entity.self)
         }
         self.annotatedEntity = annotatedEntity
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "annotated_entity", error: error)
+            throw error.nestedUnderKey("annotated_entity")
         }
+        let optionalAnnotatedEntityRawValue = JSONDictionary["optional_annotated_entity"]
         do {
-        let optionalAnnotatedEntity = try (JSONDictionary["optional_annotated_entity"]).flatMap(Entity.init(JSONObject:))
+        let optionalAnnotatedEntity = try (optionalAnnotatedEntityRawValue).flatMap(Entity.init(JSONObject:))
         self.optionalAnnotatedEntity = optionalAnnotatedEntity
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "optional_annotated_entity", error: error)
+            throw error.nestedUnderKey("optional_annotated_entity")
         }
     }
 }
@@ -193,10 +279,19 @@ extension JSONDeserializableProperty.Entity: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        guard let name = (JSONDictionary["name"] as? String) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "name", value: JSONDictionary["name"])
+        let nameRawValue = JSONDictionary["name"]
+        if nameRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("name")
+        }
+        do {
+        guard let name = (nameRawValue as? String) else {
+            // type: String
+            throw AutoJSONDeserializableError.typeMismatchError(String.self)
         }
         self.name = name
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("name")
+        }
     }
 }
 
@@ -206,21 +301,50 @@ extension MultiTypesProperties: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        guard let string = (JSONDictionary["string"] as? String) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "string", value: JSONDictionary["string"])
+        let stringRawValue = JSONDictionary["string"]
+        if stringRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("string")
+        }
+        do {
+        guard let string = (stringRawValue as? String) else {
+            // type: String
+            throw AutoJSONDeserializableError.typeMismatchError(String.self)
         }
         self.string = string
-        guard let integer = (JSONDictionary["integer"] as? Int) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "integer", value: JSONDictionary["integer"])
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("string")
+        }
+        let integerRawValue = JSONDictionary["integer"]
+        if integerRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("integer")
+        }
+        do {
+        guard let integer = (integerRawValue as? Int) else {
+            // type: Int
+            throw AutoJSONDeserializableError.typeMismatchError(Int.self)
         }
         self.integer = integer
-        let optionalInteger = (JSONDictionary["optionalInteger"] as? Int)
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("integer")
+        }
+        let optionalIntegerRawValue = JSONDictionary["optionalInteger"]
+        let optionalInteger = (optionalIntegerRawValue as? Int)
         self.optionalInteger = optionalInteger
-        guard let double = (JSONDictionary["double"] as? Double) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "double", value: JSONDictionary["double"])
+        let doubleRawValue = JSONDictionary["double"]
+        if doubleRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("double")
+        }
+        do {
+        guard let double = (doubleRawValue as? Double) else {
+            // type: Double
+            throw AutoJSONDeserializableError.typeMismatchError(Double.self)
         }
         self.double = double
-        let optionalDouble = (JSONDictionary["optionalDouble"] as? Double)
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("double")
+        }
+        let optionalDoubleRawValue = JSONDictionary["optionalDouble"]
+        let optionalDouble = (optionalDoubleRawValue as? Double)
         self.optionalDouble = optionalDouble
     }
 }
@@ -231,7 +355,8 @@ extension OptionalProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let name = (JSONDictionary["name"] as? String)
+        let nameRawValue = JSONDictionary["name"]
+        let name = (nameRawValue as? String)
         self.name = name
     }
 }
@@ -242,10 +367,19 @@ extension SinglePropertyNoAnnotation: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        guard let name = (JSONDictionary["name"] as? String) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "name", value: JSONDictionary["name"])
+        let nameRawValue = JSONDictionary["name"]
+        if nameRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("name")
+        }
+        do {
+        guard let name = (nameRawValue as? String) else {
+            // type: String
+            throw AutoJSONDeserializableError.typeMismatchError(String.self)
         }
         self.name = name
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("name")
+        }
     }
 }
 
@@ -255,10 +389,19 @@ extension SinglePropertyWithKeyPathAnnotation: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        guard let name = (JSONDictionary["label"] as? String) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "label", value: JSONDictionary["label"])
+        let nameRawValue = JSONDictionary["label"]
+        if nameRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("label")
+        }
+        do {
+        guard let name = (nameRawValue as? String) else {
+            // type: String
+            throw AutoJSONDeserializableError.typeMismatchError(String.self)
         }
         self.name = name
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("label")
+        }
     }
 }
 
@@ -268,11 +411,21 @@ extension StringEnumProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        guard let enumValue = (JSONDictionary["enumValue"] as? String).flatMap({ StringEnum(rawValue: $0) }) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumValue", value: JSONDictionary["enumValue"])
+        let enumValueRawValue = JSONDictionary["enumValue"]
+        if enumValueRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("enumValue")
+        }
+        do {
+        guard let enumValue = (enumValueRawValue as? String).flatMap({ StringEnum(rawValue: $0) }) else {
+            // type: StringEnum
+            throw AutoJSONDeserializableError.typeMismatchError(StringEnum.self)
         }
         self.enumValue = enumValue
-        let optionalEnumValue = (JSONDictionary["optionalEnumValue"] as? String).flatMap({ StringEnum(rawValue: $0) })
+        } catch let error as AutoJSONDeserializableError {
+            throw error.nestedUnderKey("enumValue")
+        }
+        let optionalEnumValueRawValue = JSONDictionary["optionalEnumValue"]
+        let optionalEnumValue = (optionalEnumValueRawValue as? String).flatMap({ StringEnum(rawValue: $0) })
         self.optionalEnumValue = optionalEnumValue
     }
 }
@@ -283,13 +436,18 @@ extension TypealiasedDateArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
+        let momentArrayRawValue = JSONDictionary["momentArray"]
+        if momentArrayRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("momentArray")
+        }
         do {
-        guard let momentArray = try (JSONDictionary["momentArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "momentArray", value: JSONDictionary["momentArray"])
+        guard let momentArray = try (momentArrayRawValue as? [Any])?.flatMap(Date.init(JSONObject:)) else {
+            // type: [Moment]
+            throw AutoJSONDeserializableError.typeMismatchError([Moment].self)
         }
         self.momentArray = momentArray
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "momentArray", error: error)
+            throw error.nestedUnderKey("momentArray")
         }
     }
 }
@@ -300,19 +458,25 @@ extension TypealiasedDateProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
+        let momentInTimeRawValue = JSONDictionary["momentInTime"]
+        if momentInTimeRawValue == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("momentInTime")
+        }
         do {
-        guard let momentInTime = try (JSONDictionary["momentInTime"]).flatMap(MomentInTime.init(JSONObject:)) else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "momentInTime", value: JSONDictionary["momentInTime"])
+        guard let momentInTime = try (momentInTimeRawValue).flatMap(MomentInTime.init(JSONObject:)) else {
+            // type: MomentInTime
+            throw AutoJSONDeserializableError.typeMismatchError(MomentInTime.self)
         }
         self.momentInTime = momentInTime
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "momentInTime", error: error)
+            throw error.nestedUnderKey("momentInTime")
         }
+        let optionalMomentInTimeRawValue = JSONDictionary["optionalMomentInTime"]
         do {
-        let optionalMomentInTime = try (JSONDictionary["optionalMomentInTime"]).flatMap(MomentInTime.init(JSONObject:))
+        let optionalMomentInTime = try (optionalMomentInTimeRawValue).flatMap(MomentInTime.init(JSONObject:))
         self.optionalMomentInTime = optionalMomentInTime
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "optionalMomentInTime", error: error)
+            throw error.nestedUnderKey("optionalMomentInTime")
         }
     }
 }

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -11,7 +11,7 @@ import Foundation
 extension ArrayProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         do {
         guard let array = try (JSONDictionary["array"] as? [Any])?.flatMap(MultiTypesProperties.init(JSONObject:)) else {
@@ -28,7 +28,7 @@ extension ArrayProperty: JSONDeserializable {
 extension BasicTypesArrayProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         guard let doubleArray = (JSONDictionary["doubleArray"] as? [Double]) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "doubleArray", value: JSONDictionary["doubleArray"])
@@ -49,7 +49,7 @@ extension BasicTypesArrayProperty: JSONDeserializable {
 extension DateArrayProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         do {
         guard let dateArray = try (JSONDictionary["dateArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else {
@@ -66,7 +66,7 @@ extension DateArrayProperty: JSONDeserializable {
 extension DateProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         do {
         guard let date = try (JSONDictionary["date"]).flatMap(Date.init(JSONObject:)) else {
@@ -89,7 +89,7 @@ extension DateProperty: JSONDeserializable {
 extension EnumArrayProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         guard let enumsArray = (JSONDictionary["enumsArray"] as? [String])?.flatMap({ StringEnum(rawValue: $0) }) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumsArray", value: JSONDictionary["enumsArray"])
@@ -102,7 +102,7 @@ extension EnumArrayProperty: JSONDeserializable {
 extension EnumWithCustomSerdeProperties: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         do {
         guard let intEnumUsingStringSerde = try (JSONDictionary["intEnumUsingStringSerde"]).flatMap(IntEnumUsingStringSerde.init(JSONObject:)) else {
@@ -133,7 +133,7 @@ extension EnumWithCustomSerdeProperties: JSONDeserializable {
 extension IntEnumProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         guard let enumValue = (JSONDictionary["enumValue"] as? Int).flatMap({ IntEnum(rawValue: $0) }) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumValue", value: JSONDictionary["enumValue"])
@@ -148,7 +148,7 @@ extension IntEnumProperty: JSONDeserializable {
 extension JSONDeserializableProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         do {
         guard let entity = try (JSONDictionary["entity"]).flatMap(Entity.init(JSONObject:)) else {
@@ -191,7 +191,7 @@ extension JSONDeserializableProperty: JSONDeserializable {
 extension JSONDeserializableProperty.Entity: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         guard let name = (JSONDictionary["name"] as? String) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "name", value: JSONDictionary["name"])
@@ -204,7 +204,7 @@ extension JSONDeserializableProperty.Entity: JSONDeserializable {
 extension MultiTypesProperties: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         guard let string = (JSONDictionary["string"] as? String) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "string", value: JSONDictionary["string"])
@@ -229,7 +229,7 @@ extension MultiTypesProperties: JSONDeserializable {
 extension OptionalProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         let name = (JSONDictionary["name"] as? String)
         self.name = name
@@ -240,7 +240,7 @@ extension OptionalProperty: JSONDeserializable {
 extension SinglePropertyNoAnnotation: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         guard let name = (JSONDictionary["name"] as? String) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "name", value: JSONDictionary["name"])
@@ -253,7 +253,7 @@ extension SinglePropertyNoAnnotation: JSONDeserializable {
 extension SinglePropertyWithKeyPathAnnotation: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         guard let name = (JSONDictionary["label"] as? String) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "label", value: JSONDictionary["label"])
@@ -266,7 +266,7 @@ extension SinglePropertyWithKeyPathAnnotation: JSONDeserializable {
 extension StringEnumProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         guard let enumValue = (JSONDictionary["enumValue"] as? String).flatMap({ StringEnum(rawValue: $0) }) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumValue", value: JSONDictionary["enumValue"])
@@ -281,7 +281,7 @@ extension StringEnumProperty: JSONDeserializable {
 extension TypealiasedDateArrayProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         do {
         guard let momentArray = try (JSONDictionary["momentArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else {
@@ -298,7 +298,7 @@ extension TypealiasedDateArrayProperty: JSONDeserializable {
 extension TypealiasedDateProperty: JSONDeserializable {
     internal init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         do {
         guard let momentInTime = try (JSONDictionary["momentInTime"]).flatMap(MomentInTime.init(JSONObject:)) else {

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -13,10 +13,14 @@ extension ArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
+        do {
         guard let array = try (JSONDictionary["array"] as? [Any])?.flatMap(MultiTypesProperties.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "array", value: JSONDictionary["array"])
         }
         self.array = array
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "array", error: error)
+        }
     }
 }
 
@@ -47,10 +51,14 @@ extension DateArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
+        do {
         guard let dateArray = try (JSONDictionary["dateArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "dateArray", value: JSONDictionary["dateArray"])
         }
         self.dateArray = dateArray
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "dateArray", error: error)
+        }
     }
 }
 
@@ -60,12 +68,20 @@ extension DateProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
+        do {
         guard let date = try (JSONDictionary["date"]).flatMap(Date.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "date", value: JSONDictionary["date"])
         }
         self.date = date
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "date", error: error)
+        }
+        do {
         let optionalDate = try (JSONDictionary["optional_date"]).flatMap(Date.init(JSONObject:))
         self.optionalDate = optionalDate
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "optional_date", error: error)
+        }
     }
 }
 
@@ -88,16 +104,28 @@ extension EnumWithCustomSerdeProperties: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
+        do {
         guard let intEnumUsingStringSerde = try (JSONDictionary["intEnumUsingStringSerde"]).flatMap(IntEnumUsingStringSerde.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "intEnumUsingStringSerde", value: JSONDictionary["intEnumUsingStringSerde"])
         }
         self.intEnumUsingStringSerde = intEnumUsingStringSerde
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "intEnumUsingStringSerde", error: error)
+        }
+        do {
         guard let customSerdeEnum = try (JSONDictionary["customSerdeEnum"]).flatMap(CustomSerdeEnum.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "customSerdeEnum", value: JSONDictionary["customSerdeEnum"])
         }
         self.customSerdeEnum = customSerdeEnum
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "customSerdeEnum", error: error)
+        }
+        do {
         let optionalCustomSerdeEnum = try (JSONDictionary["optionalCustomSerdeEnum"]).flatMap(CustomSerdeEnum.init(JSONObject:))
         self.optionalCustomSerdeEnum = optionalCustomSerdeEnum
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "optionalCustomSerdeEnum", error: error)
+        }
     }
 }
 
@@ -122,20 +150,40 @@ extension JSONDeserializableProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
+        do {
         guard let entity = try (JSONDictionary["entity"]).flatMap(Entity.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "entity", value: JSONDictionary["entity"])
         }
         self.entity = entity
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "entity", error: error)
+        }
+        do {
         let optionalEntity = try (JSONDictionary["optionalEntity"]).flatMap(Entity.init(JSONObject:))
         self.optionalEntity = optionalEntity
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "optionalEntity", error: error)
+        }
+        do {
         let nilEntity = try (JSONDictionary["nilEntity"]).flatMap(Entity.init(JSONObject:))
         self.nilEntity = nilEntity
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "nilEntity", error: error)
+        }
+        do {
         guard let annotatedEntity = try (JSONDictionary["annotated_entity"]).flatMap(Entity.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "annotated_entity", value: JSONDictionary["annotated_entity"])
         }
         self.annotatedEntity = annotatedEntity
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "annotated_entity", error: error)
+        }
+        do {
         let optionalAnnotatedEntity = try (JSONDictionary["optional_annotated_entity"]).flatMap(Entity.init(JSONObject:))
         self.optionalAnnotatedEntity = optionalAnnotatedEntity
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "optional_annotated_entity", error: error)
+        }
     }
 }
 
@@ -235,10 +283,14 @@ extension TypealiasedDateArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
+        do {
         guard let momentArray = try (JSONDictionary["momentArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "momentArray", value: JSONDictionary["momentArray"])
         }
         self.momentArray = momentArray
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "momentArray", error: error)
+        }
     }
 }
 
@@ -248,12 +300,20 @@ extension TypealiasedDateProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
+        do {
         guard let momentInTime = try (JSONDictionary["momentInTime"]).flatMap(MomentInTime.init(JSONObject:)) else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "momentInTime", value: JSONDictionary["momentInTime"])
         }
         self.momentInTime = momentInTime
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "momentInTime", error: error)
+        }
+        do {
         let optionalMomentInTime = try (JSONDictionary["optionalMomentInTime"]).flatMap(MomentInTime.init(JSONObject:))
         self.optionalMomentInTime = optionalMomentInTime
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "optionalMomentInTime", error: error)
+        }
     }
 }
 

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -24,7 +24,7 @@ extension ArrayProperty: JSONDeserializable {
         }
         self.array = array
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("array")
+            throw error.nestedUnderKey(.name("array"))
         }
     }
 }
@@ -46,7 +46,7 @@ extension BasicTypesArrayProperty: JSONDeserializable {
         }
         self.doubleArray = doubleArray
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("doubleArray")
+            throw error.nestedUnderKey(.name("doubleArray"))
         }
         let integerArrayRawValue = JSONDictionary["integerArray"]
         if integerArrayRawValue == nil {
@@ -59,7 +59,7 @@ extension BasicTypesArrayProperty: JSONDeserializable {
         }
         self.integerArray = integerArray
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("integerArray")
+            throw error.nestedUnderKey(.name("integerArray"))
         }
         let stringArrayRawValue = JSONDictionary["stringArray"]
         if stringArrayRawValue == nil {
@@ -72,7 +72,7 @@ extension BasicTypesArrayProperty: JSONDeserializable {
         }
         self.stringArray = stringArray
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("stringArray")
+            throw error.nestedUnderKey(.name("stringArray"))
         }
     }
 }
@@ -94,7 +94,7 @@ extension DateArrayProperty: JSONDeserializable {
         }
         self.dateArray = dateArray
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("dateArray")
+            throw error.nestedUnderKey(.name("dateArray"))
         }
     }
 }
@@ -116,14 +116,14 @@ extension DateProperty: JSONDeserializable {
         }
         self.date = date
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("date")
+            throw error.nestedUnderKey(.name("date"))
         }
         let optionalDateRawValue = JSONDictionary["optional_date"]
         do {
         let optionalDate = try (optionalDateRawValue).flatMap(Date.init(JSONObject:))
         self.optionalDate = optionalDate
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("optional_date")
+            throw error.nestedUnderKey(.name("optional_date"))
         }
     }
 }
@@ -145,7 +145,7 @@ extension EnumArrayProperty: JSONDeserializable {
         }
         self.enumsArray = enumsArray
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("enumsArray")
+            throw error.nestedUnderKey(.name("enumsArray"))
         }
     }
 }
@@ -167,7 +167,7 @@ extension EnumWithCustomSerdeProperties: JSONDeserializable {
         }
         self.intEnumUsingStringSerde = intEnumUsingStringSerde
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("intEnumUsingStringSerde")
+            throw error.nestedUnderKey(.name("intEnumUsingStringSerde"))
         }
         let customSerdeEnumRawValue = JSONDictionary["customSerdeEnum"]
         if customSerdeEnumRawValue == nil {
@@ -180,14 +180,14 @@ extension EnumWithCustomSerdeProperties: JSONDeserializable {
         }
         self.customSerdeEnum = customSerdeEnum
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("customSerdeEnum")
+            throw error.nestedUnderKey(.name("customSerdeEnum"))
         }
         let optionalCustomSerdeEnumRawValue = JSONDictionary["optionalCustomSerdeEnum"]
         do {
         let optionalCustomSerdeEnum = try (optionalCustomSerdeEnumRawValue).flatMap(CustomSerdeEnum.init(JSONObject:))
         self.optionalCustomSerdeEnum = optionalCustomSerdeEnum
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("optionalCustomSerdeEnum")
+            throw error.nestedUnderKey(.name("optionalCustomSerdeEnum"))
         }
     }
 }
@@ -209,7 +209,7 @@ extension IntEnumProperty: JSONDeserializable {
         }
         self.enumValue = enumValue
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("enumValue")
+            throw error.nestedUnderKey(.name("enumValue"))
         }
         let optionalEnumValueRawValue = JSONDictionary["optionalEnumValue"]
         let optionalEnumValue = (optionalEnumValueRawValue as? Int).flatMap({ IntEnum(rawValue: $0) })
@@ -234,21 +234,21 @@ extension JSONDeserializableProperty: JSONDeserializable {
         }
         self.entity = entity
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("entity")
+            throw error.nestedUnderKey(.name("entity"))
         }
         let optionalEntityRawValue = JSONDictionary["optionalEntity"]
         do {
         let optionalEntity = try (optionalEntityRawValue).flatMap(Entity.init(JSONObject:))
         self.optionalEntity = optionalEntity
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("optionalEntity")
+            throw error.nestedUnderKey(.name("optionalEntity"))
         }
         let nilEntityRawValue = JSONDictionary["nilEntity"]
         do {
         let nilEntity = try (nilEntityRawValue).flatMap(Entity.init(JSONObject:))
         self.nilEntity = nilEntity
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("nilEntity")
+            throw error.nestedUnderKey(.name("nilEntity"))
         }
         let annotatedEntityRawValue = JSONDictionary["annotated_entity"]
         if annotatedEntityRawValue == nil {
@@ -261,14 +261,14 @@ extension JSONDeserializableProperty: JSONDeserializable {
         }
         self.annotatedEntity = annotatedEntity
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("annotated_entity")
+            throw error.nestedUnderKey(.name("annotated_entity"))
         }
         let optionalAnnotatedEntityRawValue = JSONDictionary["optional_annotated_entity"]
         do {
         let optionalAnnotatedEntity = try (optionalAnnotatedEntityRawValue).flatMap(Entity.init(JSONObject:))
         self.optionalAnnotatedEntity = optionalAnnotatedEntity
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("optional_annotated_entity")
+            throw error.nestedUnderKey(.name("optional_annotated_entity"))
         }
     }
 }
@@ -290,7 +290,7 @@ extension JSONDeserializableProperty.Entity: JSONDeserializable {
         }
         self.name = name
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("name")
+            throw error.nestedUnderKey(.name("name"))
         }
     }
 }
@@ -312,7 +312,7 @@ extension MultiTypesProperties: JSONDeserializable {
         }
         self.string = string
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("string")
+            throw error.nestedUnderKey(.name("string"))
         }
         let integerRawValue = JSONDictionary["integer"]
         if integerRawValue == nil {
@@ -325,7 +325,7 @@ extension MultiTypesProperties: JSONDeserializable {
         }
         self.integer = integer
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("integer")
+            throw error.nestedUnderKey(.name("integer"))
         }
         let optionalIntegerRawValue = JSONDictionary["optionalInteger"]
         let optionalInteger = (optionalIntegerRawValue as? Int)
@@ -341,7 +341,7 @@ extension MultiTypesProperties: JSONDeserializable {
         }
         self.double = double
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("double")
+            throw error.nestedUnderKey(.name("double"))
         }
         let optionalDoubleRawValue = JSONDictionary["optionalDouble"]
         let optionalDouble = (optionalDoubleRawValue as? Double)
@@ -378,7 +378,7 @@ extension SinglePropertyNoAnnotation: JSONDeserializable {
         }
         self.name = name
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("name")
+            throw error.nestedUnderKey(.name("name"))
         }
     }
 }
@@ -400,7 +400,7 @@ extension SinglePropertyWithKeyPathAnnotation: JSONDeserializable {
         }
         self.name = name
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("label")
+            throw error.nestedUnderKey(.name("label"))
         }
     }
 }
@@ -422,7 +422,7 @@ extension StringEnumProperty: JSONDeserializable {
         }
         self.enumValue = enumValue
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("enumValue")
+            throw error.nestedUnderKey(.name("enumValue"))
         }
         let optionalEnumValueRawValue = JSONDictionary["optionalEnumValue"]
         let optionalEnumValue = (optionalEnumValueRawValue as? String).flatMap({ StringEnum(rawValue: $0) })
@@ -447,7 +447,7 @@ extension TypealiasedDateArrayProperty: JSONDeserializable {
         }
         self.momentArray = momentArray
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("momentArray")
+            throw error.nestedUnderKey(.name("momentArray"))
         }
     }
 }
@@ -469,14 +469,14 @@ extension TypealiasedDateProperty: JSONDeserializable {
         }
         self.momentInTime = momentInTime
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("momentInTime")
+            throw error.nestedUnderKey(.name("momentInTime"))
         }
         let optionalMomentInTimeRawValue = JSONDictionary["optionalMomentInTime"]
         do {
         let optionalMomentInTime = try (optionalMomentInTimeRawValue).flatMap(MomentInTime.init(JSONObject:))
         self.optionalMomentInTime = optionalMomentInTime
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("optionalMomentInTime")
+            throw error.nestedUnderKey(.name("optionalMomentInTime"))
         }
     }
 }

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -13,18 +13,25 @@ extension ArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let arrayRawValue = JSONDictionary["array"]
-        if arrayRawValue == nil {
+        if let arrayRawValue = JSONDictionary["array"], !(arrayRawValue is NSNull) {
+            do {
+                guard let castedArray = arrayRawValue as? [Any] else {
+                    throw AutoJSONDeserializableError.typeMismatchError([MultiTypesProperties].self)
+                }
+                self.array = try castedArray.enumerated().map { indexElementTuple -> MultiTypesProperties in
+                    let index = indexElementTuple.0
+                    let element = indexElementTuple.1
+                    do {
+                        return try MultiTypesProperties(JSONObject: element)
+                    } catch let error as AutoJSONDeserializableError {
+                        throw error.nestedUnderKey(.index(index))
+                    }
+                }
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("array"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("array")
-        }
-        do {
-        guard let array = try (arrayRawValue as? [Any])?.flatMap(MultiTypesProperties.init(JSONObject:)) else {
-            // type: [MultiTypesProperties]
-            throw AutoJSONDeserializableError.typeMismatchError([MultiTypesProperties].self)
-        }
-        self.array = array
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("array"))
         }
     }
 }
@@ -35,44 +42,29 @@ extension BasicTypesArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let doubleArrayRawValue = JSONDictionary["doubleArray"]
-        if doubleArrayRawValue == nil {
+        if let doubleArrayRawValue = JSONDictionary["doubleArray"], !(doubleArrayRawValue is NSNull) {
+            guard let doubleArray = doubleArrayRawValue as? [Double] else {
+                throw AutoJSONDeserializableError.typeMismatchError([Double].self, keyPath: .init(key: .name("doubleArray")))
+            }
+            self.doubleArray = doubleArray
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("doubleArray")
         }
-        do {
-        guard let doubleArray = (doubleArrayRawValue as? [Double]) else {
-            // type: [Double]
-            throw AutoJSONDeserializableError.typeMismatchError([Double].self)
-        }
-        self.doubleArray = doubleArray
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("doubleArray"))
-        }
-        let integerArrayRawValue = JSONDictionary["integerArray"]
-        if integerArrayRawValue == nil {
+        if let integerArrayRawValue = JSONDictionary["integerArray"], !(integerArrayRawValue is NSNull) {
+            guard let integerArray = integerArrayRawValue as? [Int] else {
+                throw AutoJSONDeserializableError.typeMismatchError([Int].self, keyPath: .init(key: .name("integerArray")))
+            }
+            self.integerArray = integerArray
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("integerArray")
         }
-        do {
-        guard let integerArray = (integerArrayRawValue as? [Int]) else {
-            // type: [Int]
-            throw AutoJSONDeserializableError.typeMismatchError([Int].self)
-        }
-        self.integerArray = integerArray
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("integerArray"))
-        }
-        let stringArrayRawValue = JSONDictionary["stringArray"]
-        if stringArrayRawValue == nil {
+        if let stringArrayRawValue = JSONDictionary["stringArray"], !(stringArrayRawValue is NSNull) {
+            guard let stringArray = stringArrayRawValue as? [String] else {
+                throw AutoJSONDeserializableError.typeMismatchError([String].self, keyPath: .init(key: .name("stringArray")))
+            }
+            self.stringArray = stringArray
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("stringArray")
-        }
-        do {
-        guard let stringArray = (stringArrayRawValue as? [String]) else {
-            // type: [String]
-            throw AutoJSONDeserializableError.typeMismatchError([String].self)
-        }
-        self.stringArray = stringArray
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("stringArray"))
         }
     }
 }
@@ -83,18 +75,25 @@ extension DateArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let dateArrayRawValue = JSONDictionary["dateArray"]
-        if dateArrayRawValue == nil {
+        if let dateArrayRawValue = JSONDictionary["dateArray"], !(dateArrayRawValue is NSNull) {
+            do {
+                guard let castedArray = dateArrayRawValue as? [Any] else {
+                    throw AutoJSONDeserializableError.typeMismatchError([Date].self)
+                }
+                self.dateArray = try castedArray.enumerated().map { indexElementTuple -> Date in
+                    let index = indexElementTuple.0
+                    let element = indexElementTuple.1
+                    do {
+                        return try Date(JSONObject: element)
+                    } catch let error as AutoJSONDeserializableError {
+                        throw error.nestedUnderKey(.index(index))
+                    }
+                }
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("dateArray"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("dateArray")
-        }
-        do {
-        guard let dateArray = try (dateArrayRawValue as? [Any])?.flatMap(Date.init(JSONObject:)) else {
-            // type: [Date]
-            throw AutoJSONDeserializableError.typeMismatchError([Date].self)
-        }
-        self.dateArray = dateArray
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("dateArray"))
         }
     }
 }
@@ -105,25 +104,25 @@ extension DateProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let dateRawValue = JSONDictionary["date"]
-        if dateRawValue == nil {
+        if let dateRawValue = JSONDictionary["date"], !(dateRawValue is NSNull) {
+            do {
+                let date = try Date(JSONObject: dateRawValue)
+                self.date = date
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("date"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("date")
         }
-        do {
-        guard let date = try (dateRawValue).flatMap(Date.init(JSONObject:)) else {
-            // type: Date
-            throw AutoJSONDeserializableError.typeMismatchError(Date.self)
-        }
-        self.date = date
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("date"))
-        }
-        let optionalDateRawValue = JSONDictionary["optional_date"]
-        do {
-        let optionalDate = try (optionalDateRawValue).flatMap(Date.init(JSONObject:))
-        self.optionalDate = optionalDate
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("optional_date"))
+        if let optionalDateRawValue = JSONDictionary["optional_date"], !(optionalDateRawValue is NSNull) {
+            do {
+                let optionalDate = try Date(JSONObject: optionalDateRawValue)
+                self.optionalDate = optionalDate
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("optional_date"))
+            }
+        } else {
+            self.optionalDate = nil
         }
     }
 }
@@ -134,18 +133,25 @@ extension EnumArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let enumsArrayRawValue = JSONDictionary["enumsArray"]
-        if enumsArrayRawValue == nil {
+        if let enumsArrayRawValue = JSONDictionary["enumsArray"], !(enumsArrayRawValue is NSNull) {
+            do {
+                // StringEnum
+                guard let castedArray = enumsArrayRawValue as? [String] else {
+                    throw AutoJSONDeserializableError.typeMismatchError([String].self)
+                }
+                self.enumsArray = try castedArray.enumerated().map { indexElementTuple -> StringEnum in
+                    let index = indexElementTuple.0
+                    let element = indexElementTuple.1
+                    guard let enumValue = StringEnum(rawValue: element) else {
+                        throw AutoJSONDeserializableError.typeMismatchError(StringEnum.self, keyPath: .init(key: .index(index)))
+                    }
+                    return enumValue
+                }
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("enumsArray"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("enumsArray")
-        }
-        do {
-        guard let enumsArray = (enumsArrayRawValue as? [String])?.flatMap({ StringEnum(rawValue: $0) }) else {
-            // type: [StringEnum]
-            throw AutoJSONDeserializableError.typeMismatchError([StringEnum].self)
-        }
-        self.enumsArray = enumsArray
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("enumsArray"))
         }
     }
 }
@@ -156,38 +162,35 @@ extension EnumWithCustomSerdeProperties: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let intEnumUsingStringSerdeRawValue = JSONDictionary["intEnumUsingStringSerde"]
-        if intEnumUsingStringSerdeRawValue == nil {
+        if let intEnumUsingStringSerdeRawValue = JSONDictionary["intEnumUsingStringSerde"], !(intEnumUsingStringSerdeRawValue is NSNull) {
+            do {
+                let intEnumUsingStringSerde = try IntEnumUsingStringSerde(JSONObject: intEnumUsingStringSerdeRawValue)
+                self.intEnumUsingStringSerde = intEnumUsingStringSerde
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("intEnumUsingStringSerde"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("intEnumUsingStringSerde")
         }
-        do {
-        guard let intEnumUsingStringSerde = try (intEnumUsingStringSerdeRawValue).flatMap(IntEnumUsingStringSerde.init(JSONObject:)) else {
-            // type: IntEnumUsingStringSerde
-            throw AutoJSONDeserializableError.typeMismatchError(IntEnumUsingStringSerde.self)
-        }
-        self.intEnumUsingStringSerde = intEnumUsingStringSerde
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("intEnumUsingStringSerde"))
-        }
-        let customSerdeEnumRawValue = JSONDictionary["customSerdeEnum"]
-        if customSerdeEnumRawValue == nil {
+        if let customSerdeEnumRawValue = JSONDictionary["customSerdeEnum"], !(customSerdeEnumRawValue is NSNull) {
+            do {
+                let customSerdeEnum = try CustomSerdeEnum(JSONObject: customSerdeEnumRawValue)
+                self.customSerdeEnum = customSerdeEnum
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("customSerdeEnum"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("customSerdeEnum")
         }
-        do {
-        guard let customSerdeEnum = try (customSerdeEnumRawValue).flatMap(CustomSerdeEnum.init(JSONObject:)) else {
-            // type: CustomSerdeEnum
-            throw AutoJSONDeserializableError.typeMismatchError(CustomSerdeEnum.self)
-        }
-        self.customSerdeEnum = customSerdeEnum
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("customSerdeEnum"))
-        }
-        let optionalCustomSerdeEnumRawValue = JSONDictionary["optionalCustomSerdeEnum"]
-        do {
-        let optionalCustomSerdeEnum = try (optionalCustomSerdeEnumRawValue).flatMap(CustomSerdeEnum.init(JSONObject:))
-        self.optionalCustomSerdeEnum = optionalCustomSerdeEnum
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("optionalCustomSerdeEnum"))
+        if let optionalCustomSerdeEnumRawValue = JSONDictionary["optionalCustomSerdeEnum"], !(optionalCustomSerdeEnumRawValue is NSNull) {
+            do {
+                let optionalCustomSerdeEnum = try CustomSerdeEnum(JSONObject: optionalCustomSerdeEnumRawValue)
+                self.optionalCustomSerdeEnum = optionalCustomSerdeEnum
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("optionalCustomSerdeEnum"))
+            }
+        } else {
+            self.optionalCustomSerdeEnum = nil
         }
     }
 }
@@ -198,22 +201,24 @@ extension IntEnumProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let enumValueRawValue = JSONDictionary["enumValue"]
-        if enumValueRawValue == nil {
+        if let enumValueRawValue = JSONDictionary["enumValue"], !(enumValueRawValue is NSNull) {
+            guard let castedVar = enumValueRawValue as? Int,
+                  let enumValue = IntEnum(rawValue: castedVar) else {
+                throw AutoJSONDeserializableError.typeMismatchError(IntEnum.self, keyPath: .init(key: .name("enumValue")))
+            }
+            self.enumValue = enumValue
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("enumValue")
         }
-        do {
-        guard let enumValue = (enumValueRawValue as? Int).flatMap({ IntEnum(rawValue: $0) }) else {
-            // type: IntEnum
-            throw AutoJSONDeserializableError.typeMismatchError(IntEnum.self)
+        if let optionalEnumValueRawValue = JSONDictionary["optionalEnumValue"], !(optionalEnumValueRawValue is NSNull) {
+            guard let castedVar = optionalEnumValueRawValue as? Int,
+                  let optionalEnumValue = IntEnum(rawValue: castedVar) else {
+                throw AutoJSONDeserializableError.typeMismatchError(IntEnum.self, keyPath: .init(key: .name("optionalEnumValue")))
+            }
+            self.optionalEnumValue = optionalEnumValue
+        } else {
+            self.optionalEnumValue = nil
         }
-        self.enumValue = enumValue
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("enumValue"))
-        }
-        let optionalEnumValueRawValue = JSONDictionary["optionalEnumValue"]
-        let optionalEnumValue = (optionalEnumValueRawValue as? Int).flatMap({ IntEnum(rawValue: $0) })
-        self.optionalEnumValue = optionalEnumValue
     }
 }
 
@@ -223,52 +228,55 @@ extension JSONDeserializableProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let entityRawValue = JSONDictionary["entity"]
-        if entityRawValue == nil {
+        if let entityRawValue = JSONDictionary["entity"], !(entityRawValue is NSNull) {
+            do {
+                let entity = try Entity(JSONObject: entityRawValue)
+                self.entity = entity
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("entity"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("entity")
         }
-        do {
-        guard let entity = try (entityRawValue).flatMap(Entity.init(JSONObject:)) else {
-            // type: Entity
-            throw AutoJSONDeserializableError.typeMismatchError(Entity.self)
+        if let optionalEntityRawValue = JSONDictionary["optionalEntity"], !(optionalEntityRawValue is NSNull) {
+            do {
+                let optionalEntity = try Entity(JSONObject: optionalEntityRawValue)
+                self.optionalEntity = optionalEntity
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("optionalEntity"))
+            }
+        } else {
+            self.optionalEntity = nil
         }
-        self.entity = entity
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("entity"))
+        if let nilEntityRawValue = JSONDictionary["nilEntity"], !(nilEntityRawValue is NSNull) {
+            do {
+                let nilEntity = try Entity(JSONObject: nilEntityRawValue)
+                self.nilEntity = nilEntity
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("nilEntity"))
+            }
+        } else {
+            self.nilEntity = nil
         }
-        let optionalEntityRawValue = JSONDictionary["optionalEntity"]
-        do {
-        let optionalEntity = try (optionalEntityRawValue).flatMap(Entity.init(JSONObject:))
-        self.optionalEntity = optionalEntity
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("optionalEntity"))
-        }
-        let nilEntityRawValue = JSONDictionary["nilEntity"]
-        do {
-        let nilEntity = try (nilEntityRawValue).flatMap(Entity.init(JSONObject:))
-        self.nilEntity = nilEntity
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("nilEntity"))
-        }
-        let annotatedEntityRawValue = JSONDictionary["annotated_entity"]
-        if annotatedEntityRawValue == nil {
+        if let annotatedEntityRawValue = JSONDictionary["annotated_entity"], !(annotatedEntityRawValue is NSNull) {
+            do {
+                let annotatedEntity = try Entity(JSONObject: annotatedEntityRawValue)
+                self.annotatedEntity = annotatedEntity
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("annotated_entity"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("annotated_entity")
         }
-        do {
-        guard let annotatedEntity = try (annotatedEntityRawValue).flatMap(Entity.init(JSONObject:)) else {
-            // type: Entity
-            throw AutoJSONDeserializableError.typeMismatchError(Entity.self)
-        }
-        self.annotatedEntity = annotatedEntity
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("annotated_entity"))
-        }
-        let optionalAnnotatedEntityRawValue = JSONDictionary["optional_annotated_entity"]
-        do {
-        let optionalAnnotatedEntity = try (optionalAnnotatedEntityRawValue).flatMap(Entity.init(JSONObject:))
-        self.optionalAnnotatedEntity = optionalAnnotatedEntity
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("optional_annotated_entity"))
+        if let optionalAnnotatedEntityRawValue = JSONDictionary["optional_annotated_entity"], !(optionalAnnotatedEntityRawValue is NSNull) {
+            do {
+                let optionalAnnotatedEntity = try Entity(JSONObject: optionalAnnotatedEntityRawValue)
+                self.optionalAnnotatedEntity = optionalAnnotatedEntity
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("optional_annotated_entity"))
+            }
+        } else {
+            self.optionalAnnotatedEntity = nil
         }
     }
 }
@@ -279,18 +287,13 @@ extension JSONDeserializableProperty.Entity: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let nameRawValue = JSONDictionary["name"]
-        if nameRawValue == nil {
+        if let nameRawValue = JSONDictionary["name"], !(nameRawValue is NSNull) {
+            guard let name = nameRawValue as? String else {
+                throw AutoJSONDeserializableError.typeMismatchError(String.self, keyPath: .init(key: .name("name")))
+            }
+            self.name = name
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("name")
-        }
-        do {
-        guard let name = (nameRawValue as? String) else {
-            // type: String
-            throw AutoJSONDeserializableError.typeMismatchError(String.self)
-        }
-        self.name = name
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("name"))
         }
     }
 }
@@ -301,51 +304,46 @@ extension MultiTypesProperties: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let stringRawValue = JSONDictionary["string"]
-        if stringRawValue == nil {
+        if let stringRawValue = JSONDictionary["string"], !(stringRawValue is NSNull) {
+            guard let string = stringRawValue as? String else {
+                throw AutoJSONDeserializableError.typeMismatchError(String.self, keyPath: .init(key: .name("string")))
+            }
+            self.string = string
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("string")
         }
-        do {
-        guard let string = (stringRawValue as? String) else {
-            // type: String
-            throw AutoJSONDeserializableError.typeMismatchError(String.self)
-        }
-        self.string = string
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("string"))
-        }
-        let integerRawValue = JSONDictionary["integer"]
-        if integerRawValue == nil {
+        if let integerRawValue = JSONDictionary["integer"], !(integerRawValue is NSNull) {
+            guard let integer = integerRawValue as? Int else {
+                throw AutoJSONDeserializableError.typeMismatchError(Int.self, keyPath: .init(key: .name("integer")))
+            }
+            self.integer = integer
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("integer")
         }
-        do {
-        guard let integer = (integerRawValue as? Int) else {
-            // type: Int
-            throw AutoJSONDeserializableError.typeMismatchError(Int.self)
+        if let optionalIntegerRawValue = JSONDictionary["optionalInteger"], !(optionalIntegerRawValue is NSNull) {
+            guard let optionalInteger = optionalIntegerRawValue as? Int else {
+                throw AutoJSONDeserializableError.typeMismatchError(Int.self, keyPath: .init(key: .name("optionalInteger")))
+            }
+            self.optionalInteger = optionalInteger
+        } else {
+            self.optionalInteger = nil
         }
-        self.integer = integer
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("integer"))
-        }
-        let optionalIntegerRawValue = JSONDictionary["optionalInteger"]
-        let optionalInteger = (optionalIntegerRawValue as? Int)
-        self.optionalInteger = optionalInteger
-        let doubleRawValue = JSONDictionary["double"]
-        if doubleRawValue == nil {
+        if let doubleRawValue = JSONDictionary["double"], !(doubleRawValue is NSNull) {
+            guard let double = doubleRawValue as? Double else {
+                throw AutoJSONDeserializableError.typeMismatchError(Double.self, keyPath: .init(key: .name("double")))
+            }
+            self.double = double
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("double")
         }
-        do {
-        guard let double = (doubleRawValue as? Double) else {
-            // type: Double
-            throw AutoJSONDeserializableError.typeMismatchError(Double.self)
+        if let optionalDoubleRawValue = JSONDictionary["optionalDouble"], !(optionalDoubleRawValue is NSNull) {
+            guard let optionalDouble = optionalDoubleRawValue as? Double else {
+                throw AutoJSONDeserializableError.typeMismatchError(Double.self, keyPath: .init(key: .name("optionalDouble")))
+            }
+            self.optionalDouble = optionalDouble
+        } else {
+            self.optionalDouble = nil
         }
-        self.double = double
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("double"))
-        }
-        let optionalDoubleRawValue = JSONDictionary["optionalDouble"]
-        let optionalDouble = (optionalDoubleRawValue as? Double)
-        self.optionalDouble = optionalDouble
     }
 }
 
@@ -355,9 +353,14 @@ extension OptionalProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let nameRawValue = JSONDictionary["name"]
-        let name = (nameRawValue as? String)
-        self.name = name
+        if let nameRawValue = JSONDictionary["name"], !(nameRawValue is NSNull) {
+            guard let name = nameRawValue as? String else {
+                throw AutoJSONDeserializableError.typeMismatchError(String.self, keyPath: .init(key: .name("name")))
+            }
+            self.name = name
+        } else {
+            self.name = nil
+        }
     }
 }
 
@@ -367,18 +370,13 @@ extension SinglePropertyNoAnnotation: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let nameRawValue = JSONDictionary["name"]
-        if nameRawValue == nil {
+        if let nameRawValue = JSONDictionary["name"], !(nameRawValue is NSNull) {
+            guard let name = nameRawValue as? String else {
+                throw AutoJSONDeserializableError.typeMismatchError(String.self, keyPath: .init(key: .name("name")))
+            }
+            self.name = name
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("name")
-        }
-        do {
-        guard let name = (nameRawValue as? String) else {
-            // type: String
-            throw AutoJSONDeserializableError.typeMismatchError(String.self)
-        }
-        self.name = name
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("name"))
         }
     }
 }
@@ -389,18 +387,13 @@ extension SinglePropertyWithKeyPathAnnotation: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let nameRawValue = JSONDictionary["label"]
-        if nameRawValue == nil {
+        if let nameRawValue = JSONDictionary["label"], !(nameRawValue is NSNull) {
+            guard let name = nameRawValue as? String else {
+                throw AutoJSONDeserializableError.typeMismatchError(String.self, keyPath: .init(key: .name("label")))
+            }
+            self.name = name
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("label")
-        }
-        do {
-        guard let name = (nameRawValue as? String) else {
-            // type: String
-            throw AutoJSONDeserializableError.typeMismatchError(String.self)
-        }
-        self.name = name
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("label"))
         }
     }
 }
@@ -411,22 +404,24 @@ extension StringEnumProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let enumValueRawValue = JSONDictionary["enumValue"]
-        if enumValueRawValue == nil {
+        if let enumValueRawValue = JSONDictionary["enumValue"], !(enumValueRawValue is NSNull) {
+            guard let castedVar = enumValueRawValue as? String,
+                  let enumValue = StringEnum(rawValue: castedVar) else {
+                throw AutoJSONDeserializableError.typeMismatchError(StringEnum.self, keyPath: .init(key: .name("enumValue")))
+            }
+            self.enumValue = enumValue
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("enumValue")
         }
-        do {
-        guard let enumValue = (enumValueRawValue as? String).flatMap({ StringEnum(rawValue: $0) }) else {
-            // type: StringEnum
-            throw AutoJSONDeserializableError.typeMismatchError(StringEnum.self)
+        if let optionalEnumValueRawValue = JSONDictionary["optionalEnumValue"], !(optionalEnumValueRawValue is NSNull) {
+            guard let castedVar = optionalEnumValueRawValue as? String,
+                  let optionalEnumValue = StringEnum(rawValue: castedVar) else {
+                throw AutoJSONDeserializableError.typeMismatchError(StringEnum.self, keyPath: .init(key: .name("optionalEnumValue")))
+            }
+            self.optionalEnumValue = optionalEnumValue
+        } else {
+            self.optionalEnumValue = nil
         }
-        self.enumValue = enumValue
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("enumValue"))
-        }
-        let optionalEnumValueRawValue = JSONDictionary["optionalEnumValue"]
-        let optionalEnumValue = (optionalEnumValueRawValue as? String).flatMap({ StringEnum(rawValue: $0) })
-        self.optionalEnumValue = optionalEnumValue
     }
 }
 
@@ -436,18 +431,25 @@ extension TypealiasedDateArrayProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let momentArrayRawValue = JSONDictionary["momentArray"]
-        if momentArrayRawValue == nil {
+        if let momentArrayRawValue = JSONDictionary["momentArray"], !(momentArrayRawValue is NSNull) {
+            do {
+                guard let castedArray = momentArrayRawValue as? [Any] else {
+                    throw AutoJSONDeserializableError.typeMismatchError([Date].self)
+                }
+                self.momentArray = try castedArray.enumerated().map { indexElementTuple -> Date in
+                    let index = indexElementTuple.0
+                    let element = indexElementTuple.1
+                    do {
+                        return try Date(JSONObject: element)
+                    } catch let error as AutoJSONDeserializableError {
+                        throw error.nestedUnderKey(.index(index))
+                    }
+                }
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("momentArray"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("momentArray")
-        }
-        do {
-        guard let momentArray = try (momentArrayRawValue as? [Any])?.flatMap(Date.init(JSONObject:)) else {
-            // type: [Moment]
-            throw AutoJSONDeserializableError.typeMismatchError([Moment].self)
-        }
-        self.momentArray = momentArray
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("momentArray"))
         }
     }
 }
@@ -458,25 +460,25 @@ extension TypealiasedDateProperty: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        let momentInTimeRawValue = JSONDictionary["momentInTime"]
-        if momentInTimeRawValue == nil {
+        if let momentInTimeRawValue = JSONDictionary["momentInTime"], !(momentInTimeRawValue is NSNull) {
+            do {
+                let momentInTime = try MomentInTime(JSONObject: momentInTimeRawValue)
+                self.momentInTime = momentInTime
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("momentInTime"))
+            }
+        } else {
             throw AutoJSONDeserializableError.keyNotFoundError("momentInTime")
         }
-        do {
-        guard let momentInTime = try (momentInTimeRawValue).flatMap(MomentInTime.init(JSONObject:)) else {
-            // type: MomentInTime
-            throw AutoJSONDeserializableError.typeMismatchError(MomentInTime.self)
-        }
-        self.momentInTime = momentInTime
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("momentInTime"))
-        }
-        let optionalMomentInTimeRawValue = JSONDictionary["optionalMomentInTime"]
-        do {
-        let optionalMomentInTime = try (optionalMomentInTimeRawValue).flatMap(MomentInTime.init(JSONObject:))
-        self.optionalMomentInTime = optionalMomentInTime
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("optionalMomentInTime"))
+        if let optionalMomentInTimeRawValue = JSONDictionary["optionalMomentInTime"], !(optionalMomentInTimeRawValue is NSNull) {
+            do {
+                let optionalMomentInTime = try MomentInTime(JSONObject: optionalMomentInTimeRawValue)
+                self.optionalMomentInTime = optionalMomentInTime
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("optionalMomentInTime"))
+            }
+        } else {
+            self.optionalMomentInTime = nil
         }
     }
 }

--- a/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
+++ b/Sources/AutoJSONSerialization/Extensions/AutoJSONDeserializable.generated.swift
@@ -9,176 +9,250 @@ import Foundation
 
 // MARK: - ArrayProperty AutoJSONDeserializable
 extension ArrayProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let array = (JSONObject["array"] as? [Any])?.flatMap(MultiTypesProperties.init(JSONObject:)) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let array = try (JSONDictionary["array"] as? [Any])?.flatMap(MultiTypesProperties.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "array", value: JSONDictionary["array"])
+        }
         self.array = array
     }
 }
 
 // MARK: - BasicTypesArrayProperty AutoJSONDeserializable
 extension BasicTypesArrayProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let doubleArray = (JSONObject["doubleArray"] as? [Double]) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let doubleArray = (JSONDictionary["doubleArray"] as? [Double]) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "doubleArray", value: JSONDictionary["doubleArray"])
+        }
         self.doubleArray = doubleArray
-        guard let integerArray = (JSONObject["integerArray"] as? [Int]) else { return nil }
+        guard let integerArray = (JSONDictionary["integerArray"] as? [Int]) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "integerArray", value: JSONDictionary["integerArray"])
+        }
         self.integerArray = integerArray
-        guard let stringArray = (JSONObject["stringArray"] as? [String]) else { return nil }
+        guard let stringArray = (JSONDictionary["stringArray"] as? [String]) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "stringArray", value: JSONDictionary["stringArray"])
+        }
         self.stringArray = stringArray
     }
 }
 
 // MARK: - DateArrayProperty AutoJSONDeserializable
 extension DateArrayProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let dateArray = (JSONObject["dateArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let dateArray = try (JSONDictionary["dateArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "dateArray", value: JSONDictionary["dateArray"])
+        }
         self.dateArray = dateArray
     }
 }
 
 // MARK: - DateProperty AutoJSONDeserializable
 extension DateProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let date = (JSONObject["date"]).flatMap(Date.init(JSONObject:)) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let date = try (JSONDictionary["date"]).flatMap(Date.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "date", value: JSONDictionary["date"])
+        }
         self.date = date
-        let optionalDate = (JSONObject["optional_date"]).flatMap(Date.init(JSONObject:))
+        let optionalDate = try (JSONDictionary["optional_date"]).flatMap(Date.init(JSONObject:))
         self.optionalDate = optionalDate
     }
 }
 
 // MARK: - EnumArrayProperty AutoJSONDeserializable
 extension EnumArrayProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let enumsArray = (JSONObject["enumsArray"] as? [String])?.flatMap({ StringEnum(rawValue: $0) }) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let enumsArray = (JSONDictionary["enumsArray"] as? [String])?.flatMap({ StringEnum(rawValue: $0) }) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumsArray", value: JSONDictionary["enumsArray"])
+        }
         self.enumsArray = enumsArray
     }
 }
 
 // MARK: - EnumWithCustomSerdeProperties AutoJSONDeserializable
 extension EnumWithCustomSerdeProperties: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let intEnumUsingStringSerde = (JSONObject["intEnumUsingStringSerde"]).flatMap(IntEnumUsingStringSerde.init(JSONObject:)) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let intEnumUsingStringSerde = try (JSONDictionary["intEnumUsingStringSerde"]).flatMap(IntEnumUsingStringSerde.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "intEnumUsingStringSerde", value: JSONDictionary["intEnumUsingStringSerde"])
+        }
         self.intEnumUsingStringSerde = intEnumUsingStringSerde
-        guard let customSerdeEnum = (JSONObject["customSerdeEnum"]).flatMap(CustomSerdeEnum.init(JSONObject:)) else { return nil }
+        guard let customSerdeEnum = try (JSONDictionary["customSerdeEnum"]).flatMap(CustomSerdeEnum.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "customSerdeEnum", value: JSONDictionary["customSerdeEnum"])
+        }
         self.customSerdeEnum = customSerdeEnum
-        let optionalCustomSerdeEnum = (JSONObject["optionalCustomSerdeEnum"]).flatMap(CustomSerdeEnum.init(JSONObject:))
+        let optionalCustomSerdeEnum = try (JSONDictionary["optionalCustomSerdeEnum"]).flatMap(CustomSerdeEnum.init(JSONObject:))
         self.optionalCustomSerdeEnum = optionalCustomSerdeEnum
     }
 }
 
 // MARK: - IntEnumProperty AutoJSONDeserializable
 extension IntEnumProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let enumValue = (JSONObject["enumValue"] as? Int).flatMap({ IntEnum(rawValue: $0) }) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let enumValue = (JSONDictionary["enumValue"] as? Int).flatMap({ IntEnum(rawValue: $0) }) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumValue", value: JSONDictionary["enumValue"])
+        }
         self.enumValue = enumValue
-        let optionalEnumValue = (JSONObject["optionalEnumValue"] as? Int).flatMap({ IntEnum(rawValue: $0) })
+        let optionalEnumValue = (JSONDictionary["optionalEnumValue"] as? Int).flatMap({ IntEnum(rawValue: $0) })
         self.optionalEnumValue = optionalEnumValue
     }
 }
 
 // MARK: - JSONDeserializableProperty AutoJSONDeserializable
 extension JSONDeserializableProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let entity = (JSONObject["entity"]).flatMap(Entity.init(JSONObject:)) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let entity = try (JSONDictionary["entity"]).flatMap(Entity.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "entity", value: JSONDictionary["entity"])
+        }
         self.entity = entity
-        let optionalEntity = (JSONObject["optionalEntity"]).flatMap(Entity.init(JSONObject:))
+        let optionalEntity = try (JSONDictionary["optionalEntity"]).flatMap(Entity.init(JSONObject:))
         self.optionalEntity = optionalEntity
-        let nilEntity = (JSONObject["nilEntity"]).flatMap(Entity.init(JSONObject:))
+        let nilEntity = try (JSONDictionary["nilEntity"]).flatMap(Entity.init(JSONObject:))
         self.nilEntity = nilEntity
-        guard let annotatedEntity = (JSONObject["annotated_entity"]).flatMap(Entity.init(JSONObject:)) else { return nil }
+        guard let annotatedEntity = try (JSONDictionary["annotated_entity"]).flatMap(Entity.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "annotated_entity", value: JSONDictionary["annotated_entity"])
+        }
         self.annotatedEntity = annotatedEntity
-        let optionalAnnotatedEntity = (JSONObject["optional_annotated_entity"]).flatMap(Entity.init(JSONObject:))
+        let optionalAnnotatedEntity = try (JSONDictionary["optional_annotated_entity"]).flatMap(Entity.init(JSONObject:))
         self.optionalAnnotatedEntity = optionalAnnotatedEntity
     }
 }
 
 // MARK: - JSONDeserializableProperty.Entity AutoJSONDeserializable
 extension JSONDeserializableProperty.Entity: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let name = (JSONObject["name"] as? String) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let name = (JSONDictionary["name"] as? String) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "name", value: JSONDictionary["name"])
+        }
         self.name = name
     }
 }
 
 // MARK: - MultiTypesProperties AutoJSONDeserializable
 extension MultiTypesProperties: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let string = (JSONObject["string"] as? String) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let string = (JSONDictionary["string"] as? String) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "string", value: JSONDictionary["string"])
+        }
         self.string = string
-        guard let integer = (JSONObject["integer"] as? Int) else { return nil }
+        guard let integer = (JSONDictionary["integer"] as? Int) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "integer", value: JSONDictionary["integer"])
+        }
         self.integer = integer
-        let optionalInteger = (JSONObject["optionalInteger"] as? Int)
+        let optionalInteger = (JSONDictionary["optionalInteger"] as? Int)
         self.optionalInteger = optionalInteger
-        guard let double = (JSONObject["double"] as? Double) else { return nil }
+        guard let double = (JSONDictionary["double"] as? Double) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "double", value: JSONDictionary["double"])
+        }
         self.double = double
-        let optionalDouble = (JSONObject["optionalDouble"] as? Double)
+        let optionalDouble = (JSONDictionary["optionalDouble"] as? Double)
         self.optionalDouble = optionalDouble
     }
 }
 
 // MARK: - OptionalProperty AutoJSONDeserializable
 extension OptionalProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        let name = (JSONObject["name"] as? String)
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        let name = (JSONDictionary["name"] as? String)
         self.name = name
     }
 }
 
 // MARK: - SinglePropertyNoAnnotation AutoJSONDeserializable
 extension SinglePropertyNoAnnotation: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let name = (JSONObject["name"] as? String) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let name = (JSONDictionary["name"] as? String) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "name", value: JSONDictionary["name"])
+        }
         self.name = name
     }
 }
 
 // MARK: - SinglePropertyWithKeyPathAnnotation AutoJSONDeserializable
 extension SinglePropertyWithKeyPathAnnotation: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let name = (JSONObject["label"] as? String) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let name = (JSONDictionary["label"] as? String) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "label", value: JSONDictionary["label"])
+        }
         self.name = name
     }
 }
 
 // MARK: - StringEnumProperty AutoJSONDeserializable
 extension StringEnumProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let enumValue = (JSONObject["enumValue"] as? String).flatMap({ StringEnum(rawValue: $0) }) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let enumValue = (JSONDictionary["enumValue"] as? String).flatMap({ StringEnum(rawValue: $0) }) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "enumValue", value: JSONDictionary["enumValue"])
+        }
         self.enumValue = enumValue
-        let optionalEnumValue = (JSONObject["optionalEnumValue"] as? String).flatMap({ StringEnum(rawValue: $0) })
+        let optionalEnumValue = (JSONDictionary["optionalEnumValue"] as? String).flatMap({ StringEnum(rawValue: $0) })
         self.optionalEnumValue = optionalEnumValue
     }
 }
 
 // MARK: - TypealiasedDateArrayProperty AutoJSONDeserializable
 extension TypealiasedDateArrayProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let momentArray = (JSONObject["momentArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let momentArray = try (JSONDictionary["momentArray"] as? [Any])?.flatMap(Date.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "momentArray", value: JSONDictionary["momentArray"])
+        }
         self.momentArray = momentArray
     }
 }
 
 // MARK: - TypealiasedDateProperty AutoJSONDeserializable
 extension TypealiasedDateProperty: JSONDeserializable {
-    internal init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        guard let momentInTime = (JSONObject["momentInTime"]).flatMap(MomentInTime.init(JSONObject:)) else { return nil }
+    internal init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        guard let momentInTime = try (JSONDictionary["momentInTime"]).flatMap(MomentInTime.init(JSONObject:)) else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "momentInTime", value: JSONDictionary["momentInTime"])
+        }
         self.momentInTime = momentInTime
-        let optionalMomentInTime = (JSONObject["optionalMomentInTime"]).flatMap(MomentInTime.init(JSONObject:))
+        let optionalMomentInTime = try (JSONDictionary["optionalMomentInTime"]).flatMap(MomentInTime.init(JSONObject:))
         self.optionalMomentInTime = optionalMomentInTime
     }
 }

--- a/Sources/AutoJSONSerialization/JSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/JSONDeserializable.swift
@@ -1,6 +1,18 @@
 public enum AutoJSONDeserializableError: Error {
     case invalidJSONObject(Any)
     case missingKeyOrInvalid(key: String, value: Any?)
+    indirect case nestedError(key: String, error: AutoJSONDeserializableError)
+
+    var keyPath: String {
+        switch self {
+        case .invalidJSONObject:
+            return ""
+        case .missingKeyOrInvalid(let key, _):
+            return key
+        case let .nestedError(key, error):
+            return key + "." + error.keyPath
+        }
+    }
 }
 
 public protocol JSONDeserializable {

--- a/Sources/AutoJSONSerialization/JSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/JSONDeserializable.swift
@@ -1,3 +1,7 @@
+public protocol JSONDeserializable {
+    init(JSONObject: Any) throws
+}
+
 public enum AutoJSONDeserializableError: Error {
     public enum CodingKey {
         case name(String)
@@ -67,6 +71,15 @@ public enum AutoJSONDeserializableError: Error {
     }
 }
 
-public protocol JSONDeserializable {
-    init(JSONObject: Any) throws
+import Foundation
+
+extension AutoJSONDeserializableError: LocalizedError {
+    public var failureReason: String? {
+        switch self {
+        case let .typeMismatch(type, keyPath):
+            return "Incorrect type (expected \(type)) at path \(keyPath.stringValue)"
+        case let .keyNotFound(key, keyPath):
+            return "Key '\(key)' not found at path \(keyPath.stringValue)"
+        }
+    }
 }

--- a/Sources/AutoJSONSerialization/JSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/JSONDeserializable.swift
@@ -1,5 +1,18 @@
 public enum AutoJSONDeserializableError: Error {
-    public typealias CodingKey = String
+    public enum CodingKey {
+        case name(String)
+        case index(Int)
+
+        func toString() -> String {
+            switch self {
+            case .name(let key):
+                return key
+            case .index(let index):
+                return "\(index)"
+            }
+        }
+    }
+
     public struct KeyPath {
         public var path = [CodingKey]()
 
@@ -13,7 +26,7 @@ public enum AutoJSONDeserializableError: Error {
             if path.isEmpty {
                 return "$"
             }
-            return "$." + path.joined(separator: ".")
+            return "$." + path.map { $0.toString() }.joined(separator: ".")
         }
     }
 

--- a/Sources/AutoJSONSerialization/JSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/JSONDeserializable.swift
@@ -1,3 +1,8 @@
+public enum AutoJSONDeserializableError: Error {
+    case invalidJSONObject(Any)
+    case missingKeyOrInvalid(key: String, value: Any?)
+}
+
 public protocol JSONDeserializable {
-    init?(JSONObject: Any)
+    init(JSONObject: Any) throws
 }

--- a/Sources/AutoJSONSerialization/JSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/JSONDeserializable.swift
@@ -6,15 +6,23 @@ public enum AutoJSONDeserializableError: Error {
         func toString() -> String {
             switch self {
             case .name(let key):
-                return key
+                return "." + key
             case .index(let index):
-                return "\(index)"
+                return "[\(index)]"
             }
         }
     }
 
     public struct KeyPath {
         public var path = [CodingKey]()
+
+        public init(path: [CodingKey] = []) {
+            self.path = path
+        }
+
+        public init(key: CodingKey) {
+            self.path = [key]
+        }
 
         public func prepending(key: CodingKey) -> KeyPath {
             var keyPath = self
@@ -26,7 +34,7 @@ public enum AutoJSONDeserializableError: Error {
             if path.isEmpty {
                 return "$"
             }
-            return "$." + path.map { $0.toString() }.joined(separator: ".")
+            return "$" + path.map { $0.toString() }.joined()
         }
     }
 
@@ -49,12 +57,13 @@ public enum AutoJSONDeserializableError: Error {
         }
     }
 
-    public static func typeMismatchError(_ type: Any.Type) -> AutoJSONDeserializableError {
-        return .typeMismatch(type, keyPath: KeyPath())
+    public static func typeMismatchError(_ type: Any.Type,
+                                         keyPath: KeyPath = KeyPath()) -> AutoJSONDeserializableError {
+        return .typeMismatch(type, keyPath: keyPath)
     }
 
-    public static func keyNotFoundError(_ key: String) -> AutoJSONDeserializableError {
-        return .keyNotFound(key, keyPath: KeyPath())
+    public static func keyNotFoundError(_ key: String, keyPath: KeyPath = KeyPath()) -> AutoJSONDeserializableError {
+        return .keyNotFound(key, keyPath: keyPath)
     }
 }
 

--- a/Sources/AutoJSONSerialization/JSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/JSONDeserializable.swift
@@ -21,12 +21,12 @@ public enum AutoJSONDeserializableError: Error {
         }
     }
 
-    public static func typeMismatchError(_ type: Any.Type, keyPath: KeyPath = []) -> AutoJSONDeserializableError {
-        return .typeMismatch(type, keyPath: keyPath)
+    public static func typeMismatchError(_ type: Any.Type) -> AutoJSONDeserializableError {
+        return .typeMismatch(type, keyPath: KeyPath())
     }
 
-    public static func keyNotFoundError(_ key: String, keyPath: KeyPath = []) -> AutoJSONDeserializableError {
-        return .keyNotFound(key, keyPath: keyPath)
+    public static func keyNotFoundError(_ key: String) -> AutoJSONDeserializableError {
+        return .keyNotFound(key, keyPath: KeyPath())
     }
 }
 

--- a/Sources/AutoJSONSerialization/JSONDeserializable.swift
+++ b/Sources/AutoJSONSerialization/JSONDeserializable.swift
@@ -1,17 +1,23 @@
 public enum AutoJSONDeserializableError: Error {
-    case invalidJSONObject(Any)
+    public typealias KeyPath = [String]
+
+    case typeMismatch(Any.Type, keyPath: KeyPath)
     case missingKeyOrInvalid(key: String, value: Any?)
     indirect case nestedError(key: String, error: AutoJSONDeserializableError)
 
     var keyPath: String {
         switch self {
-        case .invalidJSONObject:
-            return ""
+        case .typeMismatch(_, let keyPath):
+            return keyPath.joined(separator: ".")
         case .missingKeyOrInvalid(let key, _):
             return key
         case let .nestedError(key, error):
             return key + "." + error.keyPath
         }
+    }
+
+    public static func typeMismatchError(_ type: Any.Type, keyPath: KeyPath = []) -> AutoJSONDeserializableError {
+        return .typeMismatch(type, keyPath: keyPath)
     }
 }
 

--- a/Sources/AutoJSONSerialization/Models/EnumWithCustomSerdeProperties.swift
+++ b/Sources/AutoJSONSerialization/Models/EnumWithCustomSerdeProperties.swift
@@ -7,7 +7,7 @@ enum IntEnumUsingStringSerde: Int, JSONSerializable, JSONDeserializable {
         guard let stringValue = JSONObject as? String,
             let intValue = Int(stringValue),
             let enumValue = IntEnumUsingStringSerde(rawValue: intValue) else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError(String.self)
         }
         self = enumValue
     }
@@ -23,19 +23,19 @@ enum CustomSerdeEnum: JSONSerializable, JSONDeserializable {
 
     init(JSONObject: Any) throws {
         guard let stringValue = JSONObject as? String else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError(String.self)
         }
         var components = stringValue.components(separatedBy: "|")
-        guard let type = components.first else { throw AutoJSONDeserializableError.invalidJSONObject(JSONObject) }
+        guard let type = components.first else { throw Error.contentError(stringValue) }
         components.removeFirst()
         switch type {
         case "chair": self = .chair
         case "human":
             guard let firstName = components.first, let lastName = components.last else {
-                throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+                throw Error.contentError(stringValue)
             }
             self = .human(firstName: firstName, lastName: lastName)
-        default: throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        default: throw Error.contentError(stringValue)
         }
     }
 
@@ -44,6 +44,10 @@ enum CustomSerdeEnum: JSONSerializable, JSONDeserializable {
         case .chair: return "chair"
         case let .human(firstName, lastName): return "human|\(firstName)|\(lastName)"
         }
+    }
+
+    enum Error: Swift.Error {
+        case contentError(String)
     }
 }
 

--- a/Sources/AutoJSONSerialization/Models/EnumWithCustomSerdeProperties.swift
+++ b/Sources/AutoJSONSerialization/Models/EnumWithCustomSerdeProperties.swift
@@ -3,9 +3,13 @@ enum IntEnumUsingStringSerde: Int, JSONSerializable, JSONDeserializable {
     case two
     case six = 6
 
-    init?(JSONObject: Any) {
-        guard let stringValue = JSONObject as? String, let intValue = Int(stringValue) else { return nil }
-        self.init(rawValue: intValue)
+    init(JSONObject: Any) throws {
+        guard let stringValue = JSONObject as? String,
+            let intValue = Int(stringValue),
+            let enumValue = IntEnumUsingStringSerde(rawValue: intValue) else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        self = enumValue
     }
 
     func toJSONObject() -> Any {
@@ -17,21 +21,21 @@ enum CustomSerdeEnum: JSONSerializable, JSONDeserializable {
     case chair
     case human(firstName: String, lastName: String)
 
-    init?(JSONObject: Any) {
+    init(JSONObject: Any) throws {
         guard let stringValue = JSONObject as? String else {
-            return nil
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
         var components = stringValue.components(separatedBy: "|")
-        guard let type = components.first else { return nil }
+        guard let type = components.first else { throw AutoJSONDeserializableError.invalidJSONObject(JSONObject) }
         components.removeFirst()
         switch type {
         case "chair": self = .chair
         case "human":
             guard let firstName = components.first, let lastName = components.last else {
-                return nil
+                throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
             }
             self = .human(firstName: firstName, lastName: lastName)
-        default: return nil
+        default: throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
         }
     }
 

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -43,7 +43,7 @@ extension {{ type.name }}: JSONDeserializable {
         self.{{ variable.name }} = {{ variable.name }}
         {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable or not variable.isOptional %}
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("{{ jsonKey }}")
+            throw error.nestedUnderKey(.name("{{ jsonKey }}"))
         }
         {% endif %}
         {% else %}
@@ -61,7 +61,7 @@ extension {{ type.name }}: JSONDeserializable {
         self.{{ variable.name }} = {{ variable.name }}
         {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable or not variable.isOptional %}
         } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey("{{ jsonKey }}")
+            throw error.nestedUnderKey(.name("{{ jsonKey }}"))
         }
         {% endif %}
         {% endif %}

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -15,45 +15,53 @@ extension {{ type.name }}: JSONDeserializable {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
-        {% macro Optional arg key %}guard {{ arg }} else {
-            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "{{ key }}", value: JSONDictionary["{{ key }}"])
+        {% macro Optional arg type %}guard {{ arg }} else {
+            // type: {{ type }}
+            throw AutoJSONDeserializableError.typeMismatchError({{ type }}.self)
         }{% endmacro %}
         {% for variable in type.storedVariables %}
         {% set jsonKey %}{{ variable.annotations.JSONKey|default:variable.name }}{% endset %}
+        {% set rawVariableName %}{{ variable.name }}RawValue{% endset %}
+        let {{rawVariableName }} = JSONDictionary["{{ jsonKey }}"]
+        {% ifnot variable.isOptional %}
+        if {{ rawVariableName }} == nil {
+            throw AutoJSONDeserializableError.keyNotFoundError("{{ jsonKey }}")
+        }
+        {% endif %}
         {% ifnot variable.isArray %}
         {% set castType %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}{% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ variable.type.rawTypeName.name }}{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
         {% set itemOperation %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}.flatMap({ {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
-        {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}
+        {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable or not variable.isOptional %}
         do {
         {% endif %}
-        {% set Assignment %}let {{ variable.name }} = {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}try {% endif %}(JSONDictionary["{{ jsonKey }}"]{% if castType %} as? {{ castType }}{% endif %}){{ itemOperation }}{% endset %}
+        {% set Assignment %}let {{ variable.name }} = {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}try {% endif %}({{ rawVariableName }}{% if castType %} as? {{ castType }}{% endif %}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}
         {% else %}
-        {% call Optional Assignment jsonKey %}
+        {% call Optional Assignment variable.typeName %}
         {% endif %}
         self.{{ variable.name }} = {{ variable.name }}
-        {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}
+        {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable or not variable.isOptional %}
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "{{ jsonKey }}", error: error)
+            throw error.nestedUnderKey("{{ jsonKey }}")
         }
         {% endif %}
         {% else %}
         {% set castType %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}[Any]{% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}[{{ variable.typeName.array.elementType.rawTypeName.name }}]{% else %}{{ variable.typeName }}{% endif %}{% endif %}{% endset %}
         {% set itemOperation %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}?.flatMap({{ variable.typeName.array.elementTypeName.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}?.flatMap({ {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
-        {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}
+        {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable or not variable.isOptional %}
         do {
         {% endif %}
-        {% set Assignment %}let {{ variable.name }} = {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}try {% endif %}(JSONDictionary["{{ jsonKey }}"] as? {{ castType }}){{ itemOperation }}{% endset %}
+        {% set Assignment %}let {{ variable.name }} = {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}try {% endif %}({{ rawVariableName }} as? {{ castType }}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}
         {% else %}
-        {% call Optional Assignment jsonKey %}
+        {% call Optional Assignment variable.typeName %}
         {% endif %}
         self.{{ variable.name }} = {{ variable.name }}
-        {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}
+        {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable or not variable.isOptional %}
         } catch let error as AutoJSONDeserializableError {
-            throw AutoJSONDeserializableError.nestedError(key: "{{ jsonKey }}", error: error)
+            throw error.nestedUnderKey("{{ jsonKey }}")
         }
         {% endif %}
         {% endif %}

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -23,23 +23,40 @@ extension {{ type.name }}: JSONDeserializable {
         {% ifnot variable.isArray %}
         {% set castType %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}{% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ variable.type.rawTypeName.name }}{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
         {% set itemOperation %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}.flatMap({ {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
+        {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}
+        do {
+        {% endif %}
         {% set Assignment %}let {{ variable.name }} = {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}try {% endif %}(JSONDictionary["{{ jsonKey }}"]{% if castType %} as? {{ castType }}{% endif %}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}
         {% else %}
         {% call Optional Assignment jsonKey %}
         {% endif %}
+        self.{{ variable.name }} = {{ variable.name }}
+        {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "{{ jsonKey }}", error: error)
+        }
+        {% endif %}
         {% else %}
         {% set castType %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}[Any]{% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}[{{ variable.typeName.array.elementType.rawTypeName.name }}]{% else %}{{ variable.typeName }}{% endif %}{% endif %}{% endset %}
         {% set itemOperation %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}?.flatMap({{ variable.typeName.array.elementTypeName.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}?.flatMap({ {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
+        {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}
+        do {
+        {% endif %}
         {% set Assignment %}let {{ variable.name }} = {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}try {% endif %}(JSONDictionary["{{ jsonKey }}"] as? {{ castType }}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}
         {% else %}
         {% call Optional Assignment jsonKey %}
         {% endif %}
-        {% endif %}
         self.{{ variable.name }} = {{ variable.name }}
+        {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}
+        } catch let error as AutoJSONDeserializableError {
+            throw AutoJSONDeserializableError.nestedError(key: "{{ jsonKey }}", error: error)
+        }
+        {% endif %}
+        {% endif %}
         {% endfor %}
     }
 }

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -11,27 +11,32 @@ import Sourcery_AutoJSONSerializable
 // MARK: - {{ type.name }} AutoJSONDeserializable
 extension {{ type.name }}: JSONDeserializable {
 {% if type.supertype|annotated:"AutoJSONDeserializable" %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoJSONDeserializable {% endif %}
-    {{ type.accessLevel }} init?(JSONObject: Any) {
-        guard let JSONObject = JSONObject as? [String: Any] else { return nil }
-        {% macro Optional arg %}guard {{ arg }} else { return nil }{% endmacro %}
+    {{ type.accessLevel }} init(JSONObject: Any) throws {
+        guard let JSONDictionary = JSONObject as? [String: Any] else {
+            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+        }
+        {% macro Optional arg key %}guard {{ arg }} else {
+            throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "{{ key }}", value: JSONDictionary["{{ key }}"])
+        }{% endmacro %}
         {% for variable in type.storedVariables %}
+        {% set jsonKey %}{{ variable.annotations.JSONKey|default:variable.name }}{% endset %}
         {% ifnot variable.isArray %}
         {% set castType %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}{% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ variable.type.rawTypeName.name }}{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
         {% set itemOperation %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}.flatMap({ {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
-        {% set Assignment %}let {{ variable.name }} = (JSONObject["{{ variable.annotations.JSONKey|default:variable.name }}"]{% if castType %} as? {{ castType }}{% endif %}){{ itemOperation }}{% endset %}
+        {% set Assignment %}let {{ variable.name }} = {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}try {% endif %}(JSONDictionary["{{ jsonKey }}"]{% if castType %} as? {{ castType }}{% endif %}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}
         {% else %}
-        {% call Optional Assignment %}
+        {% call Optional Assignment jsonKey %}
         {% endif %}
         {% else %}
         {% set castType %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}[Any]{% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}[{{ variable.typeName.array.elementType.rawTypeName.name }}]{% else %}{{ variable.typeName }}{% endif %}{% endif %}{% endset %}
         {% set itemOperation %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}?.flatMap({{ variable.typeName.array.elementTypeName.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}?.flatMap({ {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
-        {% set Assignment %}let {{ variable.name }} = (JSONObject["{{ variable.annotations.JSONKey|default:variable.name }}"] as? {{ castType }}){{ itemOperation }}{% endset %}
+        {% set Assignment %}let {{ variable.name }} = {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}try {% endif %}(JSONDictionary["{{ jsonKey }}"] as? {{ castType }}){{ itemOperation }}{% endset %}
         {% if variable.isOptional %}
         {{ Assignment }}
         {% else %}
-        {% call Optional Assignment %}
+        {% call Optional Assignment jsonKey %}
         {% endif %}
         {% endif %}
         self.{{ variable.name }} = {{ variable.name }}

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -13,7 +13,7 @@ extension {{ type.name }}: JSONDeserializable {
 {% if type.supertype|annotated:"AutoJSONDeserializable" %} THIS WONT COMPILE, WE DONT SUPPORT INHERITANCE for AutoJSONDeserializable {% endif %}
     {{ type.accessLevel }} init(JSONObject: Any) throws {
         guard let JSONDictionary = JSONObject as? [String: Any] else {
-            throw AutoJSONDeserializableError.invalidJSONObject(JSONObject)
+            throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         {% macro Optional arg key %}guard {{ arg }} else {
             throw AutoJSONDeserializableError.missingKeyOrInvalid(key: "{{ key }}", value: JSONDictionary["{{ key }}"])

--- a/Templates/AutoJSONDeserializable.stencil
+++ b/Templates/AutoJSONDeserializable.stencil
@@ -16,55 +16,85 @@ extension {{ type.name }}: JSONDeserializable {
             throw AutoJSONDeserializableError.typeMismatchError([String: Any].self)
         }
         {% macro Optional arg type %}guard {{ arg }} else {
-            // type: {{ type }}
             throw AutoJSONDeserializableError.typeMismatchError({{ type }}.self)
         }{% endmacro %}
         {% for variable in type.storedVariables %}
         {% set jsonKey %}{{ variable.annotations.JSONKey|default:variable.name }}{% endset %}
         {% set rawVariableName %}{{ variable.name }}RawValue{% endset %}
-        let {{rawVariableName }} = JSONDictionary["{{ jsonKey }}"]
-        {% ifnot variable.isOptional %}
-        if {{ rawVariableName }} == nil {
+        if let {{rawVariableName }} = JSONDictionary["{{ jsonKey }}"], !({{ rawVariableName }} is NSNull) {
+            {% ifnot variable.isArray %}
+            {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}
+            do {
+                let {{ variable.name }} = try {{ variable.unwrappedTypeName }}(JSONObject: {{ rawVariableName }})
+                self.{{ variable.name }} = {{ variable.name }}
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("{{ jsonKey }}"))
+            }
+            {% elif variable.type.kind == "enum" and variable.type.rawTypeName %}
+            guard {% if variable.type.rawTypeName.name %}let castedVar = {{ rawVariableName }} as? {{ variable.type.rawTypeName.name }},
+                  {% endif %}let {{ variable.name }} = {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: {% if variable.type.rawTypeName.name %}castedVar{% else %}{{ rawVariableName }}{% endif %}) else {
+                throw AutoJSONDeserializableError.typeMismatchError({{ variable.actualTypeName.unwrappedTypeName }}.self, keyPath: .init(key: .name("{{ jsonKey}}")))
+            }
+            self.{{ variable.name }} = {{ variable.name }}
+            {% elif variable.unwrappedTypeName %}
+            guard let {{ variable.name }} = {{ rawVariableName }} as? {{ variable.unwrappedTypeName }} else {
+                throw AutoJSONDeserializableError.typeMismatchError({{  variable.unwrappedTypeName  }}.self, keyPath: .init(key: .name("{{ jsonKey}}")))
+            }
+            self.{{ variable.name }} = {{ variable.name }}
+            {% else %}
+            self.{{ variable.name }} = {{ rawVariableName }}
+            {% endif %}
+            {% else %}
+            {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}
+            do {
+                guard let castedArray = {{ rawVariableName }} as? [Any] else {
+                    throw AutoJSONDeserializableError.typeMismatchError([{{ variable.typeName.array.elementTypeName.unwrappedTypeName }}].self)
+                }
+                self.{{ variable.name }} = try castedArray.enumerated().map { indexElementTuple -> {{ variable.typeName.array.elementTypeName.unwrappedTypeName }} in
+                    let index = indexElementTuple.0
+                    let element = indexElementTuple.1
+                    do {
+                        return try {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(JSONObject: element)
+                    } catch let error as AutoJSONDeserializableError {
+                        throw error.nestedUnderKey(.index(index))
+                    }
+                }
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("{{ jsonKey }}"))
+            }
+            {% elif variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}
+            do {
+                // {{ variable.typeName.array.elementType.name }}
+                guard let castedArray = {{ rawVariableName }} as? [{{ variable.typeName.array.elementType.rawTypeName.name }}] else {
+                    throw AutoJSONDeserializableError.typeMismatchError([{{ variable.typeName.array.elementType.rawTypeName.name }}].self)
+                }
+                self.{{ variable.name }} = try castedArray.enumerated().map { indexElementTuple -> {{ variable.typeName.array.elementType.name }} in
+                    let index = indexElementTuple.0
+                    let element = indexElementTuple.1
+                    guard let enumValue = {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: element) else {
+                        throw AutoJSONDeserializableError.typeMismatchError({{ variable.typeName.array.elementType.name }}.self, keyPath: .init(key: .index(index)))
+                    }
+                    return enumValue
+                }
+            } catch let error as AutoJSONDeserializableError {
+                throw error.nestedUnderKey(.name("{{ jsonKey }}"))
+            }
+            {% elif variable.typeName %}
+            guard let {{ variable.name }} = {{ rawVariableName }} as? {{ variable.typeName }} else {
+                throw AutoJSONDeserializableError.typeMismatchError({{  variable.typeName  }}.self, keyPath: .init(key: .name("{{ jsonKey}}")))
+            }
+            self.{{ variable.name }} = {{ variable.name }}
+            {% else %}
+            self.{{ variable.name }} = {{ rawVariableName }}
+            {% endif %}
+            {% endif %}
+        } else {
+            {% if variable.isOptional %}
+            self.{{ variable.name }} = nil
+            {% else %}
             throw AutoJSONDeserializableError.keyNotFoundError("{{ jsonKey }}")
+            {% endif %}
         }
-        {% endif %}
-        {% ifnot variable.isArray %}
-        {% set castType %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}{% else %}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}{{ variable.type.rawTypeName.name }}{% else %}{{ variable.unwrappedTypeName }}{% endif %}{% endif %}{% endset %}
-        {% set itemOperation %}{% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}.flatMap({{ variable.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.type.kind == "enum" and variable.type.rawTypeName %}.flatMap({ {{ variable.actualTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
-        {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable or not variable.isOptional %}
-        do {
-        {% endif %}
-        {% set Assignment %}let {{ variable.name }} = {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable %}try {% endif %}({{ rawVariableName }}{% if castType %} as? {{ castType }}{% endif %}){{ itemOperation }}{% endset %}
-        {% if variable.isOptional %}
-        {{ Assignment }}
-        {% else %}
-        {% call Optional Assignment variable.typeName %}
-        {% endif %}
-        self.{{ variable.name }} = {{ variable.name }}
-        {% if variable.type|annotated:"AutoJSONDeserializable" or variable.type.based.JSONDeserializable or not variable.isOptional %}
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("{{ jsonKey }}"))
-        }
-        {% endif %}
-        {% else %}
-        {% set castType %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}[Any]{% else %}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}[{{ variable.typeName.array.elementType.rawTypeName.name }}]{% else %}{{ variable.typeName }}{% endif %}{% endif %}{% endset %}
-        {% set itemOperation %}{% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}?.flatMap({{ variable.typeName.array.elementTypeName.unwrappedTypeName }}.init(JSONObject:)){%else%}{% if variable.typeName.array.elementType.kind == "enum" and variable.typeName.array.elementType.rawTypeName %}?.flatMap({ {{ variable.typeName.array.elementTypeName.unwrappedTypeName }}(rawValue: $0) }){% endif %}{% endif %}{% endset %}
-        {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable or not variable.isOptional %}
-        do {
-        {% endif %}
-        {% set Assignment %}let {{ variable.name }} = {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable %}try {% endif %}({{ rawVariableName }} as? {{ castType }}){{ itemOperation }}{% endset %}
-        {% if variable.isOptional %}
-        {{ Assignment }}
-        {% else %}
-        {% call Optional Assignment variable.typeName %}
-        {% endif %}
-        self.{{ variable.name }} = {{ variable.name }}
-        {% if variable.typeName.array.elementType|annotated:"AutoJSONDeserializable" or variable.typeName.array.elementType.based.JSONDeserializable or not variable.isOptional %}
-        } catch let error as AutoJSONDeserializableError {
-            throw error.nestedUnderKey(.name("{{ jsonKey }}"))
-        }
-        {% endif %}
-        {% endif %}
         {% endfor %}
     }
 }

--- a/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
@@ -5,17 +5,39 @@ class AutoJSONDeserializableTests: XCTestCase {
     func test_singlePropertyDeserialization() {
         let jsonObject: [String: Any] = ["name": "value"]
 
-        guard let object = SinglePropertyNoAnnotation(JSONObject: jsonObject) else {
+        guard let object = try? SinglePropertyNoAnnotation(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
         XCTAssertEqual(object.name, "value")
     }
 
+    func test_singlePropertyDeserialization_misspelledKey() throws {
+        let jsonObject: [String: Any] = ["anme": "value"]
+
+        do {
+            _ = try SinglePropertyNoAnnotation(JSONObject: jsonObject)
+        } catch let AutoJSONDeserializableError.missingKeyOrInvalid(key, value) {
+            XCTAssertEqual(key, "name")
+            XCTAssertNil(value)
+        }
+    }
+
+    func test_singlePropertyDeserialization_invalidValue() throws {
+        let jsonObject: [String: Any] = ["name": 13]
+
+        do {
+            _ = try SinglePropertyNoAnnotation(JSONObject: jsonObject)
+        } catch let AutoJSONDeserializableError.missingKeyOrInvalid(key, value) {
+            XCTAssertEqual(key, "name")
+            XCTAssertEqual(value as? Int, 13)
+        }
+    }
+
     func test_singleAnnotatedPropertyDeserialization() {
         let jsonObject: [String: Any] = ["label": "value"]
 
-        guard let object = SinglePropertyWithKeyPathAnnotation(JSONObject: jsonObject) else {
+        guard let object = try? SinglePropertyWithKeyPathAnnotation(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -29,7 +51,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           "double": 66.6
         ]
 
-        guard let object = MultiTypesProperties(JSONObject: jsonObject) else {
+        guard let object = try? MultiTypesProperties(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -41,7 +63,7 @@ class AutoJSONDeserializableTests: XCTestCase {
     func test_OptionalPropertyDeserialization() {
         let jsonObject: [String: Any] = ["name": NSNull()]
 
-        guard let object = OptionalProperty(JSONObject: jsonObject) else {
+        guard let object = try? OptionalProperty(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -56,7 +78,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           "optional_annotated_entity": ["name": "optionalAnnotatedValue"]
         ]
 
-        guard let object = JSONDeserializableProperty(JSONObject: jsonObject) else {
+        guard let object = try? JSONDeserializableProperty(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -67,13 +89,29 @@ class AutoJSONDeserializableTests: XCTestCase {
         XCTAssertNil(object.nilEntity)
     }
 
+    func test_JSONDeserializablePropertyDeserialization_misspelledNestedAttribute() throws {
+        let jsonObject: [String: Any] = [
+            "entity": ["name": "value"],
+            "optionalEntity": ["name": "optionalValue"],
+            "annotated_entity": ["anme": "annotatedValue"],
+            "optional_annotated_entity": ["name": "optionalAnnotatedValue"]
+        ]
+
+        do {
+            _ = try JSONDeserializableProperty(JSONObject: jsonObject)
+        } catch let AutoJSONDeserializableError.missingKeyOrInvalid(key, value) {
+            XCTAssertEqual(key, "name")
+            XCTAssertNil(value)
+        }
+    }
+
     func test_DatePropertyDeserialization() {
         let jsonObject: [String: Any] = [
           "date": "1985-04-12T23:20:50Z",
           "optional_date": "1996-12-19T16:39:57-08:00"
         ]
 
-        guard let object = DateProperty(JSONObject: jsonObject) else {
+        guard let object = try? DateProperty(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -87,7 +125,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           "optionalMomentInTime": "1996-12-19T16:39:57-08:00"
         ]
 
-        guard let object = TypealiasedDateProperty(JSONObject: jsonObject) else {
+        guard let object = try? TypealiasedDateProperty(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -107,7 +145,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           ]
         ]
 
-        guard let object = ArrayProperty(JSONObject: jsonObject), let firstItem = object.array.first else {
+        guard let object = try? ArrayProperty(JSONObject: jsonObject), let firstItem = object.array.first else {
             XCTFail()
             return
         }
@@ -123,7 +161,7 @@ class AutoJSONDeserializableTests: XCTestCase {
         ]
         let expectedItem = Date(timeIntervalSince1970: 482196050)
 
-        guard let object = DateArrayProperty(JSONObject: jsonObject), let firstItem = object.dateArray.first else {
+        guard let object = try? DateArrayProperty(JSONObject: jsonObject), let firstItem = object.dateArray.first else {
             XCTFail()
             return
         }
@@ -136,7 +174,7 @@ class AutoJSONDeserializableTests: XCTestCase {
         ]
         let expectedItem = Date(timeIntervalSince1970: 482196050)
 
-        guard let object = TypealiasedDateArrayProperty(JSONObject: jsonObject),
+        guard let object = try? TypealiasedDateArrayProperty(JSONObject: jsonObject),
               let firstItem = object.momentArray.first else {
             XCTFail()
             return
@@ -151,7 +189,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           "stringArray": ["A", "B", "C"]
         ]
 
-        guard let object = BasicTypesArrayProperty(JSONObject: jsonObject) else {
+        guard let object = try? BasicTypesArrayProperty(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -166,7 +204,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           "optionalEnumValue": "assigned_value"
         ]
 
-        guard let object = StringEnumProperty(JSONObject: jsonObject) else {
+        guard let object = try? StringEnumProperty(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -180,7 +218,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           "optionalEnumValue": 4
         ]
 
-        guard let object = IntEnumProperty(JSONObject: jsonObject) else {
+        guard let object = try? IntEnumProperty(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -193,7 +231,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           "enumsArray": ["sameName", "assigned_value"]
         ]
 
-        guard let object = EnumArrayProperty(JSONObject: jsonObject) else {
+        guard let object = try? EnumArrayProperty(JSONObject: jsonObject) else {
             XCTFail()
             return
         }
@@ -208,7 +246,7 @@ class AutoJSONDeserializableTests: XCTestCase {
           "optionalCustomSerdeEnum": "chair"
         ]
 
-        guard let object = EnumWithCustomSerdeProperties(JSONObject: jsonObject) else {
+        guard let object = try? EnumWithCustomSerdeProperties(JSONObject: jsonObject) else {
             XCTFail()
             return
         }

--- a/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
@@ -99,9 +99,8 @@ class AutoJSONDeserializableTests: XCTestCase {
 
         do {
             _ = try JSONDeserializableProperty(JSONObject: jsonObject)
-        } catch let AutoJSONDeserializableError.missingKeyOrInvalid(key, value) {
-            XCTAssertEqual(key, "name")
-            XCTAssertNil(value)
+        } catch let error as AutoJSONDeserializableError {
+            XCTAssertEqual(error.keyPath, "annotated_entity.name")
         }
     }
 
@@ -196,6 +195,35 @@ class AutoJSONDeserializableTests: XCTestCase {
         XCTAssertEqual(object.doubleArray, [1.2, 3.4])
         XCTAssertEqual(object.integerArray, [1, 2, 3, 4])
         XCTAssertEqual(object.stringArray, ["A", "B", "C"])
+    }
+
+    func test_that_arrayDeserializationFailsEntirely_ifOneItemCannotBeDeserialized() {
+        let jsonObject = [
+            "array": [
+                [
+                    "string": "value",
+                    "integer": 42,
+                    "optionalInteger": 24,
+                    "double": 66.6
+                ],
+                [
+                    "string": "failing",
+                    "integer": "42",
+                    "optionalInteger": 24,
+                    "double": 66.6
+                ],
+                [
+                    "string": "otherValue",
+                    "integer": 24,
+                    "optionalInteger": 42,
+                    "double": 9.99
+                ]
+            ]
+        ]
+
+        XCTAssertThrowsError(try ArrayProperty(JSONObject: jsonObject)) { error in
+            XCTAssertEqual((error as? AutoJSONDeserializableError)?.keyPath, "array.integer")
+        }
     }
 
     func test_StringEnumPropertyDeserialization() {

--- a/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
@@ -12,25 +12,29 @@ class AutoJSONDeserializableTests: XCTestCase {
         XCTAssertEqual(object.name, "value")
     }
 
-    func test_singlePropertyDeserialization_misspelledKey() throws {
+    func test_singlePropertyDeserialization_misspelledKey() {
         let jsonObject: [String: Any] = ["anme": "value"]
 
         do {
             _ = try SinglePropertyNoAnnotation(JSONObject: jsonObject)
-        } catch let AutoJSONDeserializableError.missingKeyOrInvalid(key, value) {
+        } catch let AutoJSONDeserializableError.keyNotFound(key, keyPath) {
             XCTAssertEqual(key, "name")
-            XCTAssertNil(value)
+            XCTAssertEqual(keyPath, [])
+        } catch {
+            XCTFail("Unexpected error \(error)")
         }
     }
 
-    func test_singlePropertyDeserialization_invalidValue() throws {
+    func test_singlePropertyDeserialization_invalidValue() {
         let jsonObject: [String: Any] = ["name": 13]
 
         do {
             _ = try SinglePropertyNoAnnotation(JSONObject: jsonObject)
-        } catch let AutoJSONDeserializableError.missingKeyOrInvalid(key, value) {
-            XCTAssertEqual(key, "name")
-            XCTAssertEqual(value as? Int, 13)
+        } catch let AutoJSONDeserializableError.typeMismatch(type, keyPath) {
+            XCTAssertEqual(keyPath, ["name"])
+            XCTAssertTrue(type == String.self)
+        } catch {
+            XCTFail("Unexpected error \(error)")
         }
     }
 
@@ -99,8 +103,11 @@ class AutoJSONDeserializableTests: XCTestCase {
 
         do {
             _ = try JSONDeserializableProperty(JSONObject: jsonObject)
-        } catch let error as AutoJSONDeserializableError {
-            XCTAssertEqual(error.keyPath, "annotated_entity.name")
+        } catch let AutoJSONDeserializableError.keyNotFound(key, keyPath) {
+            XCTAssertEqual(key, "name")
+            XCTAssertEqual(keyPath, ["annotated_entity"])
+        } catch {
+            XCTFail("Unexpected error \(error)")
         }
     }
 

--- a/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
@@ -229,7 +229,7 @@ class AutoJSONDeserializableTests: XCTestCase {
         ]
 
         XCTAssertThrowsError(try ArrayProperty(JSONObject: jsonObject)) { error in
-            XCTAssertEqual((error as? AutoJSONDeserializableError)?.keyPath, "$.array.integer")
+            XCTAssertEqual((error as? AutoJSONDeserializableError)?.keyPath, "$.array[1].integer")
         }
     }
 

--- a/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
+++ b/Tests/AutoJSONSerializationTests/AutoJSONDeserializableTests.swift
@@ -19,7 +19,7 @@ class AutoJSONDeserializableTests: XCTestCase {
             _ = try SinglePropertyNoAnnotation(JSONObject: jsonObject)
         } catch let AutoJSONDeserializableError.keyNotFound(key, keyPath) {
             XCTAssertEqual(key, "name")
-            XCTAssertEqual(keyPath, [])
+            XCTAssertEqual(keyPath.stringValue, "$")
         } catch {
             XCTFail("Unexpected error \(error)")
         }
@@ -31,7 +31,7 @@ class AutoJSONDeserializableTests: XCTestCase {
         do {
             _ = try SinglePropertyNoAnnotation(JSONObject: jsonObject)
         } catch let AutoJSONDeserializableError.typeMismatch(type, keyPath) {
-            XCTAssertEqual(keyPath, ["name"])
+            XCTAssertEqual(keyPath.stringValue, "$.name")
             XCTAssertTrue(type == String.self)
         } catch {
             XCTFail("Unexpected error \(error)")
@@ -105,7 +105,7 @@ class AutoJSONDeserializableTests: XCTestCase {
             _ = try JSONDeserializableProperty(JSONObject: jsonObject)
         } catch let AutoJSONDeserializableError.keyNotFound(key, keyPath) {
             XCTAssertEqual(key, "name")
-            XCTAssertEqual(keyPath, ["annotated_entity"])
+            XCTAssertEqual(keyPath.stringValue, "$.annotated_entity")
         } catch {
             XCTFail("Unexpected error \(error)")
         }
@@ -229,7 +229,7 @@ class AutoJSONDeserializableTests: XCTestCase {
         ]
 
         XCTAssertThrowsError(try ArrayProperty(JSONObject: jsonObject)) { error in
-            XCTAssertEqual((error as? AutoJSONDeserializableError)?.keyPath, "array.integer")
+            XCTAssertEqual((error as? AutoJSONDeserializableError)?.keyPath, "$.array.integer")
         }
     }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -23,6 +23,7 @@ extension AutoJSONDeserializableTests {
     ("test_DateArrayPropertyDeserialization", test_DateArrayPropertyDeserialization),
     ("test_TypealiasedDateArrayPropertyDeserialization", test_TypealiasedDateArrayPropertyDeserialization),
     ("test_BasicTypesArrayPropertyDeserialization", test_BasicTypesArrayPropertyDeserialization),
+    ("test_that_arrayDeserializationFailsEntirely_ifOneItemCannotBeDeserialized", test_that_arrayDeserializationFailsEntirely_ifOneItemCannotBeDeserialized),
     ("test_StringEnumPropertyDeserialization", test_StringEnumPropertyDeserialization),
     ("test_IntEnumPropertyDeserialization", test_IntEnumPropertyDeserialization),
     ("test_EnumArrayPropertyDeserialization", test_EnumArrayPropertyDeserialization),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -10,10 +10,13 @@ import XCTest
 extension AutoJSONDeserializableTests {
   static var allTests = [
     ("test_singlePropertyDeserialization", test_singlePropertyDeserialization),
+    ("test_singlePropertyDeserialization_misspelledKey", test_singlePropertyDeserialization_misspelledKey),
+    ("test_singlePropertyDeserialization_invalidValue", test_singlePropertyDeserialization_invalidValue),
     ("test_singleAnnotatedPropertyDeserialization", test_singleAnnotatedPropertyDeserialization),
     ("test_MultiTypesPropertiesDeserialization", test_MultiTypesPropertiesDeserialization),
     ("test_OptionalPropertyDeserialization", test_OptionalPropertyDeserialization),
     ("test_JSONDeserializablePropertyDeserialization", test_JSONDeserializablePropertyDeserialization),
+    ("test_JSONDeserializablePropertyDeserialization_misspelledNestedAttribute", test_JSONDeserializablePropertyDeserialization_misspelledNestedAttribute),
     ("test_DatePropertyDeserialization", test_DatePropertyDeserialization),
     ("test_TypealiasedDatePropertyDeserialization", test_TypealiasedDatePropertyDeserialization),
     ("test_ArrayPropertyDeserialization", test_ArrayPropertyDeserialization),


### PR DESCRIPTION
This changes the `JSONDeserializable` API and uses `init(JSONObject: Any) throws` instead of `init?(JSONObject: Any)`.
The deserialisation code will now throw `AutoJSONDeserializableError`s which will contain information on:
- what went wrong (incorrect type found in JSON or missing key)
- the path of the failing JSON object

`AutoJSONDeserializableError` implements `LocalizedError` which will show the path as a [`JSONPath` string](http://goessner.net/articles/JsonPath/).